### PR TITLE
Requeueing and stash

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 # RabbitMQ connection URL
-REGISTRY_URL=amqp://localhost
+REGISTRY_URL=amqp://guest:guest@localhost
 
 # RabbitMQ Consumer prefetch value (How many tasks can do simultaneously)
 SIMULTANEOUS_TASKS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - curl -O http://localhost:15672/cli/rabbitmqadmin
   - chmod +x rabbitmqadmin
   - curl -O https://raw.githubusercontent.com/codex-team/hawk.registry/master/config/rabbit.definitions.json
-  - ./rabbitmqadmin import rabbit.definitions.json
+  - sudo ./rabbitmqadmin import rabbit.definitions.json
 script:
   - yarn lint
   - jest --coverage && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,17 @@ addons:
     packages:
       - rabbitmq-server
 before_install:
-  - sudo rabbitmq-plugins enable rabbitmq_management
-  - curl -O http://localhost:15672/cli/rabbitmqadmin
-  - chmod +x rabbitmqadmin
-  - curl -O https://raw.githubusercontent.com/codex-team/hawk.registry/master/config/rabbit.definitions.json
-  - ./rabbitmqadmin -q import rabbit.definitions.json
   - chmod +x ./bin/env-config.sh
   - ./bin/env-config.sh
   - yarn add global jest codecov
 install:
   - yarn install
+before_script:
+  - sudo rabbitmq-plugins enable rabbitmq_management
+  - curl -O http://localhost:15672/cli/rabbitmqadmin
+  - chmod +x rabbitmqadmin
+  - curl -O https://raw.githubusercontent.com/codex-team/hawk.registry/master/config/rabbit.definitions.json
+  - ./rabbitmqadmin import rabbit.definitions.json
 script:
   - yarn lint
   - jest --coverage && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial
+sudo: required
 language: node_js
 node_js:
   - "11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ addons:
     packages:
       - rabbitmq-server
 before_install:
+  - rabbitmq-plugins enable rabbitmq_management
+  - curl -O http://localhost:15672/cli/rabbitmqadmin
+  - chmod +x rabbitmqadmin
   - curl -O https://raw.githubusercontent.com/codex-team/hawk.registry/master/config/rabbit.definitions.json
-  - rabbitmqadmin -q import rabbit.definitions.json
+  - ./rabbitmqadmin -q import rabbit.definitions.json
   - chmod +x ./bin/env-config.sh
   - ./bin/env-config.sh
   - yarn add global jest codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     packages:
       - rabbitmq-server
 before_install:
-  - rabbitmq-plugins enable rabbitmq_management
+  - sudo rabbitmq-plugins enable rabbitmq_management
   - curl -O http://localhost:15672/cli/rabbitmqadmin
   - chmod +x rabbitmqadmin
   - curl -O https://raw.githubusercontent.com/codex-team/hawk.registry/master/config/rabbit.definitions.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ addons:
     packages:
       - rabbitmq-server
 before_install:
+  - curl -O https://raw.githubusercontent.com/codex-team/hawk.registry/master/config/rabbit.definitions.json
+  - rabbitmqadmin -q import rabbit.definitions.json
   - chmod +x ./bin/env-config.sh
   - ./bin/env-config.sh
   - yarn add global jest codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: thursty
+dist: trusty
 sudo: required
 language: node_js
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
-dist: xenial
+dist: thursty
 sudo: required
 language: node_js
 node_js:
   - "11"
 services:
   - mongodb
-addons:
-  apt:
-    packages:
-      - rabbitmq-server
+  - rabbitmq
 before_install:
-  - chmod +x ./bin/env-config.sh
-  - ./bin/env-config.sh
   - yarn add global jest codecov
 install:
   - yarn install
 before_script:
+  - chmod +x ./bin/env-config.sh
+  - ./bin/env-config.sh
   - sudo rabbitmq-plugins enable rabbitmq_management
   - curl -O http://localhost:15672/cli/rabbitmqadmin
   - chmod +x rabbitmqadmin

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Registry - RabbitMQ
 
 > Feel free to tune your setting in `ecosystem.config.js` file, [more info](https://pm2.io/doc/en/runtime/reference/ecosystem-file/)
 
+## Error handling
+
+If an error is thrown inside `handle` method it will be ignored, except if it is `CriticalError` or `NonCriticalError`
+
+On `CriticalError` the currently processing message will be requeued to the same queue in Registry using `Worker.requeue` method
+
+On `NonCriticalError` the currently processing message will be queued to stash queue in Registry using `Worker.sendToStash` method
+
 ## Env vars
 
 | Variable           | Description                                                                                              | Default value      |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Registry - RabbitMQ
 
 - Edit `.env` file (see more below)
 
-- Use `worker.start()` to start your worker. You may write a simple runner like [this](workers/nodejs/runner.js)
+- Use `worker.start()` to start your worker. You **should** write a simple runner like [this](workers/nodejs/runner.js)
 
 - Set `LOG_LEVEL` to `verbose` if you want message logs
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -140,11 +140,11 @@ class Worker {
    * @abstract
    */
   async handle(msg) {
-    throw Error('Unimplemented');
+    throw new Error('Unimplemented');
   }
 
   /**
-   * Requeue a message to Registry
+   * Requeue a message to original queue in Registry
    * Invoked on `CriticalError` in `handle` method to not lose any data
    *
    * @param {Object} msg - Message object from consume method
@@ -156,7 +156,7 @@ class Worker {
   }
 
   /**
-   * Requeue all processing message to Registry
+   * Requeue all processing message to their original queues in Registry
    * Invoked on `finish` method to send all messages to dead-letter queue
    * Should be invoked on process stop not to lose any data
    *
@@ -193,7 +193,7 @@ class Worker {
   async processMsg(msg) {
     try {
       if (msg) {
-        this.logger.verbose('Received message', {
+        this.logger.verbose('Received message:\n', {
           message: msg.content.toString()
         });
         await this.handle(msg);
@@ -204,13 +204,15 @@ class Worker {
     } catch (e) {
       // Send back message to registry since we failed to handle it
       if (e instanceof CriticalError) {
+        this.logger.info('Requeueing msg');
         this.requeue(msg);
       }
       if (e instanceof NonCriticalError) {
+        this.logger.info('Sending msg to stash');
         this.sendToStash(msg);
       }
 
-      this.logger.error(e);
+      this.logger.error('An error occured:\n', e);
     }
   }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -144,6 +144,43 @@ class Worker {
   }
 
   /**
+   * Requeue a message to Registry
+   * Invoked on `CriticalError` in `handle` method to not lose any data
+   *
+   * @param {Object} msg - Message object from consume method
+   * @param {Buffer} msg.content - Message content
+   * @memberof Worker
+   */
+  async requeue(msg) {
+    await this.channel.nack(msg);
+  }
+
+  /**
+   * Requeue all processing message to Registry
+   * Invoked on `finish` method to send all messages to dead-letter queue
+   * Should be invoked on process stop not to lose any data
+   *
+   * @param {Object} msg - Message object from consume method
+   * @param {Buffer} msg.content - Message content
+   * @memberof Worker
+   */
+  async requeueAll(msg) {
+    await this.channel.nackAll();
+  }
+
+  /**
+   * Enqueue a message to stash queue
+   * Invoked on `NonCriticalError` in `handle` method to not lose any data
+   *
+   * @param {Object} msg - Message object from consume method
+   * @param {Buffer} msg.content - Message content
+   * @memberof Worker
+   */
+  async sendToStash(msg) {
+    await this.channel.reject(msg, false);
+  }
+
+  /**
    * High order message process function
    * Calls `handle(msg)` to do actual work.
    * After that does all the stuff connected to RabbitMQ (ACK, etc)
@@ -166,8 +203,14 @@ class Worker {
       this.channel.ack(msg);
     } catch (e) {
       // Send back message to registry since we failed to handle it
-      this.channel.nack(msg);
-      console.error(e);
+      if (e instanceof CriticalError) {
+        this.requeue(msg);
+      }
+      if (e instanceof NonCriticalError) {
+        this.sendToStash(msg);
+      }
+
+      this.logger.error(e);
     }
   }
 
@@ -202,12 +245,22 @@ class Worker {
     if (this._consumerTag) {
       // Cancel the consumer
       await this.channel.cancel(this._consumerTag);
+
+      /**
+       * @todo Check the right sequence cancel-nackall or nackall-cancel?
+       */
+      // Requeue all messages
+      await this.requeueAll();
+
+      // Set consumerTag to null after we requeued all messages
       this._consumerTag = null;
+      this.channel = null;
     }
   }
 
   /**
-   * Finish everything (in case you need to stop handling but not disconnect)
+   * Unsubscribe and disconnect
+   * Requeues unhandled messages
    *
    * @memberof Worker
    */
@@ -226,7 +279,7 @@ class Worker {
 class CriticalError extends Error {}
 
 /**
- * Class for no-critical errors
+ * Class for non-critical errors
  * have not to stop process
  * @class DataStructError
  * @extends {Error}
@@ -238,7 +291,7 @@ class NonCriticalError extends Error {}
  * @class ParsingError
  * @extends {Error}
  */
-class ParsingError extends CriticalError {}
+class ParsingError extends NonCriticalError {}
 
 /**
  * Class for database errors in workers

--- a/lib/worker.test.js
+++ b/lib/worker.test.js
@@ -99,15 +99,9 @@ describe('Worker', () => {
 
     worker.type = '';
 
-    try {
-      await worker.start();
-    } catch (e) {
-      expect(e).toEqual(
-        new Error(
-          'Worker type is not defined! Implement `get type()` fucntion.'
-        )
-      );
-    }
+    await expect(worker.start()).rejects.toThrow(
+      new Error('Worker type is not defined! Implement `get type()` fucntion.')
+    );
   });
 
   test('handle() throws error if it is not implemented', async () => {

--- a/lib/worker.test.js
+++ b/lib/worker.test.js
@@ -64,14 +64,17 @@ class TestWorker extends Worker {
 }
 
 describe('Worker', () => {
-  let worker;
+  let conn;
+  let channel;
+
+  let worker = new Worker();
 
   /**
    * Add messages to queue before tests
    **/
   beforeAll(async () => {
-    const conn = await amqp.connect(process.env.REGISTRY_URL);
-    const channel = await conn.createChannel();
+    conn = await amqp.connect(process.env.REGISTRY_URL);
+    channel = await conn.createChannel();
 
     await channel.assertQueue(WORKER_TYPE);
 
@@ -81,6 +84,40 @@ describe('Worker', () => {
 
     await channel.close();
     await conn.close();
+  });
+
+  afterAll(async () => {
+    await worker.finish();
+  });
+
+  test('.type throws error if it is not defined', async () => {
+    await expect(() => worker.type).toThrow();
+  });
+
+  test('start() throws error if type is not defined', async () => {
+    expect.assertions(1);
+
+    worker.type = '';
+
+    try {
+      await worker.start();
+    } catch (e) {
+      expect(e).toEqual(
+        new Error(
+          'Worker type is not defined! Implement `get type()` fucntion.'
+        )
+      );
+    }
+  });
+
+  test('handle() throws error if it is not implemented', async () => {
+    expect.assertions(1);
+
+    try {
+      await worker.handle({ content: Buffer.from('test') });
+    } catch (e) {
+      expect(e).toEqual(new Error('Unimplemented'));
+    }
   });
 
   it('creates instance', async () => {

--- a/lib/workerFailover.test.js
+++ b/lib/workerFailover.test.js
@@ -1,0 +1,180 @@
+const path = require('path');
+const amqp = require('amqplib');
+
+const { Worker, NonCriticalError, CriticalError } = require('./worker');
+
+require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
+
+/**
+ * Test worker type
+ */
+const WORKER_TYPE = 'errors/nodejs';
+
+/**
+ * Stash queue name
+ */
+const STASH_QUEUE = 'stash/nodejs';
+
+/**
+ * Unique id to differenciate message
+ */
+const UID = parseInt(Math.random() * 100);
+
+const TEST_MSG = JSON.stringify({
+  message: `ReferenceError: nonexistant_func${UID} is not defined`,
+  type: 'ReferenceError',
+  stack: `ReferenceError: nonexistant_func${UID} is not defined\n    at namedFunc (/home/nick/stuff/hawk.workers/tools/nodejs/bomber.js:42:7)\n    at main (/home/nick/stuff/hawk.workers/tools/nodejs/bomber.js:64:5)\n    at Object.\u003canonymous\u003e (/home/nick/stuff/hawk.workers/tools/nodejs/bomber.js:74:1)\n    at Module._compile (internal/modules/cjs/loader.js:734:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:745:10)\n    at Module.load (internal/modules/cjs/loader.js:626:32)\n    at tryModuleLoad (internal/modules/cjs/loader.js:566:12)\n    at Function.Module._load (internal/modules/cjs/loader.js:558:3)\n    at Function.Module.runMain (internal/modules/cjs/loader.js:797:12)\n    at executeUserCode (internal/bootstrap/node.js:526:15)`,
+  time: new Date().toISOString(),
+  context: 'Exception in namedFunc'
+});
+
+let consumed = false;
+
+/**
+ * Async sleep
+ *
+ * @param {number} ms
+ * @returns Promise
+ */
+const sleep = ms => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+};
+
+/**
+ * Test base worker class
+ *
+ * @class TestWorker
+ * @extends {Worker}
+ */
+class TestWorker extends Worker {
+  /**
+   *
+   *
+   * @readonly
+   * @memberof TestWorker
+   */
+  get type() {
+    return WORKER_TYPE;
+  }
+}
+
+/**
+ * Worker class for testing stash
+ *
+ * @class StashTestWorker
+ * @extends {TestWorker}
+ */
+class StashTestWorker extends TestWorker {
+  /**
+   * Message handle function
+   *
+   * @param {Object} msg Message object from consume method
+   * @param {Buffer} msg.content Message content
+   * @memberof StashTestWorker
+   */
+  async handle(msg) {
+    if (msg) {
+      // Show jest that we consumed a message
+      consumed = true;
+
+      // Unsubscribe since we want to receive only one message
+      this.unsubscribe();
+
+      // Trow NonCriticalError to make `processMessage` send our message to stash
+      throw new NonCriticalError('Test Noncritical failure');
+    }
+  }
+}
+
+/**
+ * Worker class for testing requeueing
+ *
+ * @class RequeueTestWorker
+ * @extends {TestWorker}
+ */
+class RequeueTestWorker extends TestWorker {
+  /**
+   * Message handle function
+   *
+   * @param {Object} msg Message object from consume method
+   * @param {Buffer} msg.content Message content
+   * @memberof RequeueTestWorker
+   */
+  async handle(msg) {
+    if (msg) {
+      // Show jest that we consumed a message
+      consumed = true;
+
+      // Unsubscribe since we want to receive only one message
+      this.unsubscribe();
+
+      // Throw CriticalError to make `processMessage` requeue our message
+      throw new CriticalError('Test critical failure');
+    }
+  }
+}
+
+describe('Worker failover', () => {
+  let conn;
+  let channel;
+
+  let worker;
+
+  /**
+   * Make connection to Registry first
+   **/
+  beforeAll(async () => {
+    conn = await amqp.connect(process.env.REGISTRY_URL);
+    channel = await conn.createChannel();
+
+    await channel.assertQueue(WORKER_TYPE);
+  });
+
+  /**
+   * Before each test set `consumed` to false
+   * and publish test message
+   */
+  beforeEach(async () => {
+    consumed = false;
+    channel.publish('errors', WORKER_TYPE, Buffer.from(TEST_MSG));
+  });
+
+  afterEach(async () => {
+    await worker.finish();
+  });
+  /**
+   * Close all connections after tests
+   */
+  afterAll(async () => {
+    await channel.close();
+    await conn.close();
+  });
+
+  it('sends message to stash', async () => {
+    worker = new StashTestWorker();
+    await worker.start();
+
+    await sleep(1000);
+
+    const received = await channel.get(STASH_QUEUE, { noAck: true });
+
+    await expect(consumed).toBe(true);
+    await expect(received).toMatchObject({
+      content: Buffer.from(TEST_MSG)
+    });
+  });
+
+  it('requeues message', async () => {
+    worker = new RequeueTestWorker();
+    await worker.start();
+
+    await sleep(1000);
+
+    const received = await channel.get(WORKER_TYPE, { noAck: true });
+
+    await expect(consumed).toBe(true);
+    await expect(received).toMatchObject({
+      content: Buffer.from(TEST_MSG)
+    });
+  });
+});

--- a/tools/nodejs/bomber.js
+++ b/tools/nodejs/bomber.js
@@ -22,7 +22,7 @@ const Hawk = require('@codexteam/hawk.nodejs');
 /**
  * Hawk catcher url
  */
-const CATCHER_URL = process.env.CATCHER_URL || 'http://localhost:3000/catcher';
+const CATCHER_URL = process.env.CATCHER_URL || 'http://localhost:3000/';
 
 /**
  * Hawk token

--- a/workers/nodejs/index.js
+++ b/workers/nodejs/index.js
@@ -132,7 +132,7 @@ class NodeJSWorker extends Worker {
     try {
       await db.saveEvent({ catcherType: this.type, payload });
     } catch (e) {
-      throw DatabaseError(e);
+      throw new DatabaseError(e);
     }
   }
 }

--- a/workers/nodejs/index.js
+++ b/workers/nodejs/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 require('dotenv').config({ path: path.resolve(__dirname, '.env') });
 
-const { Worker, ParsingError } = require('../../lib/worker');
+const { Worker, ParsingError, DatabaseError } = require('../../lib/worker');
 const db = require('../../lib/db/mongoose-controller');
 
 /**
@@ -129,7 +129,11 @@ class NodeJSWorker extends Worker {
       context: eventRaw.comment
     };
 
-    await db.saveEvent({ catcherType: this.type, payload });
+    try {
+      await db.saveEvent({ catcherType: this.type, payload });
+    } catch (e) {
+      throw DatabaseError(e);
+    }
   }
 }
 

--- a/workers/nodejs/runner.js
+++ b/workers/nodejs/runner.js
@@ -23,7 +23,7 @@ const main = async () => {
     } else {
       console.error('Uncaught exception:');
     }
-    console.error(err);
+    worker.logger.error(err);
     exitHandler();
   };
 
@@ -38,8 +38,8 @@ const main = async () => {
 
   process.on('SIGINT', exitHandler);
   process.on('SIGTERM', exitHandler);
-  // process.on('uncaughtException', exceptionHandler);
-  // process.on('unhandledRejection', exceptionHandler);
+  process.on('uncaughtException', exceptionHandler);
+  process.on('unhandledRejection', exceptionHandler);
 };
 
 main();

--- a/workers/nodejs/runner.js
+++ b/workers/nodejs/runner.js
@@ -38,8 +38,8 @@ const main = async () => {
 
   process.on('SIGINT', exitHandler);
   process.on('SIGTERM', exitHandler);
-  process.on('uncaughtException', exceptionHandler);
-  process.on('unhandledRejection', exceptionHandler);
+  // process.on('uncaughtException', exceptionHandler);
+  // process.on('unhandledRejection', exceptionHandler);
 };
 
 main();


### PR DESCRIPTION
В базовый класс `Worker` были добавлены методы:
- `requeue` - возвращает сообщение в ту очередь, откуда оно пришло
- `requeueAll` - тоже самое, только для всех сообщений в обработке
- `sendToStash` - отправка сообщения в "стеш", где оно будет обрабатываться в дальнейшем

При возникновении `NonCriticalError` сообщение отправляется в стеш
При возникновении `CriticalError` (воркер падает или завершается) сообщение идет обратно в очередь, т.к. его обработка была прервана

Эти ошибки можно кидать в `Worker.handle`, чтобы отправить сообщение туда, куда нужно

При вызове `Worker.finish()` воркер отправляет все сообщения обратно в очередь. Этот метод вызывается при падении воркера

Closes #17 