### PR TITLE
Fix workers names dictionary

### DIFF
--- a/lib/workerNames.js
+++ b/lib/workerNames.js
@@ -1,8 +1,12 @@
+/**
+ * This file contains mapping of available workers to their Registry queue names
+ *
+ * 1. Get a list of available workers by a listing of /workers directory
+ * 2. Map queue name got from the `workerType` property of worker's package.json file
+ */
 const fs = require('fs');
 const path = require('path');
-
 const workersDir = fs.readdirSync(path.resolve(__dirname, '..', 'workers'), { withFileTypes: true });
-
 const workers = {};
 
 workersDir.forEach(file => {
@@ -10,7 +14,7 @@ workersDir.forEach(file => {
     return;
   }
 
-  const pkgPath = path.resolve(__dirname, '..', 'workers', file.name, ' package.json');
+  const pkgPath = path.resolve(__dirname, '..', 'workers', file.name, 'package.json');
 
   if (!fs.existsSync(pkgPath)) {
     return;


### PR DESCRIPTION
The current version of file contains a broken worker names dictionary with extra space in the path.

So in master, workers can not add tasks to each other, because they can't get queue name.