### PR TITLE
fix(js): trim source code lines

### DIFF
--- a/lib/utils/string.ts
+++ b/lib/utils/string.ts
@@ -14,5 +14,5 @@ export function rightTrim(content: string, maxLen = 140): string {
     return content;
   }
 
-  return content.substr(0, maxLen)  + '…';
+  return content.substr(0, maxLen) + '…';
 }

--- a/lib/utils/string.ts
+++ b/lib/utils/string.ts
@@ -1,0 +1,18 @@
+/**
+ * String helpers
+ */
+
+/**
+ * Trims source code line content to max length
+ * Adds «...» in case of trimming
+ *
+ * @param content - content to trim
+ * @param maxLen - trimming criteria
+ */
+export function rightTrim(content: string, maxLen = 140): string {
+  if (content.length <= maxLen) {
+    return content;
+  }
+
+  return content.substr(0, maxLen)  + '…';
+}

--- a/lib/utils/string.ts
+++ b/lib/utils/string.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * Trims source code line content to max length
+ * Trims string to max length
  * Adds «...» in case of trimming
  *
  * @param content - content to trim

--- a/workers/javascript/src/index.ts
+++ b/workers/javascript/src/index.ts
@@ -11,6 +11,7 @@ import * as pkg from '../package.json';
 import { JavaScriptEventWorkerTask } from '../types/javascript-event-worker-task';
 import HawkCatcher from '@hawk.so/nodejs';
 import Crypto from '../../../lib/utils/crypto';
+import { rightTrim } from '../../../lib/utils/string';
 
 /**
  * Worker for handling Javascript events
@@ -273,7 +274,7 @@ export default class JavascriptEventWorker extends EventWorker {
     return focusedLines.map((line, idx) => {
       return {
         line: Math.max(original.line - margin + idx, 1),
-        content: line,
+        content: rightTrim(line),
       } as SourceCodeLine;
     });
   }


### PR DESCRIPTION
We want to prevent a memory leak from storing long source code lines:

<img width="1846" alt="image" src="https://user-images.githubusercontent.com/3684889/108542237-8aba8b80-72f4-11eb-852d-be2fce22af9f.png">

