### PR TITLE
do not throw error if lastChargeDate is undefined

### DIFF
--- a/workers/paymaster/src/index.ts
+++ b/workers/paymaster/src/index.ts
@@ -137,7 +137,7 @@ export default class PaymasterWorker extends Worker {
          * Skip workspace without lastChargeDate
          */
         if (!workspace.lastChargeDate) {
-          const error = new Error('Workspace without lastChargeDate detected');
+          const error = new Error('[Paymaster] Workspace without lastChargeDate detected');
 
           HawkCatcher.send(error, {
             workspaceId: workspace._id,

--- a/workers/paymaster/src/index.ts
+++ b/workers/paymaster/src/index.ts
@@ -131,8 +131,8 @@ export default class PaymasterWorker extends Worker {
   private async handleWorkspaceSubscriptionCheckEvent(): Promise<void> {
     const workspaces = await this.workspaces.find({}).toArray();
 
-    const result = await Promise.all(workspaces.map(
-      (workspace) => {
+    const result = await Promise.all(workspaces
+      .filter(workspace => {
         /**
          * Skip workspace without lastChargeDate
          */
@@ -142,11 +142,15 @@ export default class PaymasterWorker extends Worker {
           HawkCatcher.send(error, {
             workspaceId: workspace._id,
           });
+
+          return false;
         }
 
-        return this.processWorkspaceSubscriptionCheck(workspace);
-      }
-    ));
+        return true;
+      })
+      .map(
+        (workspace) => this.processWorkspaceSubscriptionCheck(workspace)
+      ));
 
     await this.sendReport(result);
   }

--- a/workers/paymaster/src/index.ts
+++ b/workers/paymaster/src/index.ts
@@ -142,8 +142,6 @@ export default class PaymasterWorker extends Worker {
           HawkCatcher.send(error, {
             workspaceId: workspace._id,
           });
-
-          throw error;
         }
 
         return this.processWorkspaceSubscriptionCheck(workspace);


### PR DESCRIPTION
Paymaster doesn't work now because of this error. 

In case such an error occurs, the paymaster should notify us about it via the hawk, but not complete the process.