### PR TITLE
fix(grouper): fix parallel events increment

### DIFF
--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -126,6 +126,8 @@ export default class GrouperWorker extends Worker {
         if (e.code?.toString() === DB_DUPLICATE_KEY_ERROR) {
           HawkCatcher.send(new Error('[Grouper] MongoError: E11000 duplicate key error collection'));
           await this.handle(task);
+
+          return;
         } else {
           throw e;
         }


### PR DESCRIPTION
When many similar events processed in parallel, check for `isFirstOccurence` returns falsy-false value since we have no db lock. So all second events are processed as the first one.

We have a special try-catch statement that handles this case by catching Mongo "duplicate error". This statement re-runs processing for a particular event. But looks like we've lost `return` there, so on each re-run increment was added anyway