### PR TITLE
fix: not increment affected users if user is not provided

### DIFF
--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -113,6 +113,8 @@ export default class GrouperWorker extends Worker {
 
     if (isFirstOccurrence) {
       try {
+        const incrementAffectedUsers = task.event.user ? true : false;
+
         /**
          * Insert new event
          */
@@ -121,13 +123,13 @@ export default class GrouperWorker extends Worker {
           totalCount: 1,
           catcherType: task.catcherType,
           payload: task.event,
-          usersAffected: 1,
+          usersAffected: incrementAffectedUsers ? 1 : 0,
         } as GroupedEventDBScheme);
 
         /**
          * Increment daily affected users for the first event
          */
-        incrementDailyAffectedUsers = true;
+        incrementDailyAffectedUsers = incrementAffectedUsers;
       } catch (e) {
         /**
          * If we caught Database duplication error, then another worker thread has already saved it to the database

--- a/workers/grouper/tests/index.test.ts
+++ b/workers/grouper/tests/index.test.ts
@@ -250,7 +250,14 @@ describe('GrouperWorker', () => {
       await worker.handle(generateTask({ user: undefined }));
       await worker.handle(generateTask({ user: undefined }));
 
-      expect((await dailyEventsCollection.findOne({})).affectedUsers).toBe(1);
+      expect((await dailyEventsCollection.findOne({})).affectedUsers).toBe(0);
+    });
+
+    test('Should not increment daily affected users if user is not provided', async () => {
+      await worker.handle(generateTask({ user: undefined }));
+      await worker.handle(generateTask({ user: undefined }));
+
+      expect((await eventsCollection.findOne({})).usersAffected).toBe(0);
     });
 
     test('Should stringify payload`s addons and context fields', async () => {


### PR DESCRIPTION
1. Removed incrementing affected users if user is not provided for the first event
2. Fixed test for daily, added test for event