### PR TITLE
chore(redis-helper): add prefix to Redis error

### DIFF
--- a/workers/grouper/src/redisHelper.ts
+++ b/workers/grouper/src/redisHelper.ts
@@ -31,7 +31,7 @@ export default class RedisHelper {
 
     this.redisClient.on('error', (error) => {
       if (error) {
-        this.logger.error(error);
+        this.logger.error('Redis error: ', error);
         HawkCatcher.send(error);
       }
     });


### PR DESCRIPTION
This pull request includes a minor but important change to the error logging in the `RedisHelper` class. The change improves the clarity of error messages by adding a descriptive prefix.

* [`workers/grouper/src/redisHelper.ts`](diffhunk://#diff-0f3c95511a0d5fd7bcb85a43d18a09fc2faeb4bfdcbb316f4e66b3e2bd10b0a5L34-R34): Updated the error logging to include 'Redis error: ' as a prefix to the error message.