### PR TITLE
Chore(notifications): added verbose logs for notification rules validation and sender

### DIFF
--- a/workers/notifier/src/index.ts
+++ b/workers/notifier/src/index.ts
@@ -65,18 +65,9 @@ export default class NotifierWorker extends Worker {
        */
       const rules = await this.getFittedRules(projectId, event);
 
-      this.logger.info(`Found ${rules} fitted rules for the event for event ${event.groupHash}`);
-
+      this.logger.info(`Found ${rules.length} fitted rules for the event ${event.groupHash}`);
+      
       for (const rule of rules) {
-        /**
-         * If rule is disabled no need to store data in redis
-         */
-        if (rule.isEnabled === false) {
-          this.logger.info(`Rule ${rule._id} is disabled, skipping`);
-          
-          continue;
-        }
-
         /**
          * If validation for rule with whatToReceive.New passed, then event is new and we can send it to channels
          */
@@ -133,6 +124,8 @@ export default class NotifierWorker extends Worker {
         try {
           new RuleValidator(rule, event).checkAll();
         } catch (e) {
+          this.logger.info(`Rule ${rule._id} does not match becasue of ${e}, skipping...`);
+
           return false;
         }
 

--- a/workers/notifier/src/validator.ts
+++ b/workers/notifier/src/validator.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import logger from '../../../lib/logger';
 import { NotifierEvent } from '../types/notifier-task';
 import { Rule } from '../types/rule';
 
@@ -47,7 +48,7 @@ export default class RuleValidator {
     const { rule } = this;
 
     if (!rule.isEnabled) {
-      throw Error('Rule is disabled');
+      throw Error('rule is disabled');
     }
 
     return this;
@@ -66,7 +67,7 @@ export default class RuleValidator {
       (event.isNew && rule.whatToReceive === WhatToReceive.New);
 
     if (!result) {
-      throw Error('Event doesn\'t match `what to receive` filter');
+      throw Error('event doesn\'t match `what to receive` filter');
     }
 
     return this;
@@ -91,7 +92,7 @@ export default class RuleValidator {
     }
 
     if (!result) {
-      throw Error('Event title doesn\'t include required words');
+      throw Error('event title doesn\'t include required words');
     }
 
     return this;
@@ -116,7 +117,7 @@ export default class RuleValidator {
     }
 
     if (!result) {
-      throw Error('Event title includes unwanted words');
+      throw Error('event title includes unwanted words');
     }
 
     return this;

--- a/workers/notifier/src/validator.ts
+++ b/workers/notifier/src/validator.ts
@@ -1,6 +1,5 @@
 'use strict';
 
-import logger from '../../../lib/logger';
 import { NotifierEvent } from '../types/notifier-task';
 import { Rule } from '../types/rule';
 

--- a/workers/notifier/tests/validator.test.ts
+++ b/workers/notifier/tests/validator.test.ts
@@ -35,7 +35,7 @@ describe('RuleValidator', () => {
 
       const validator = new RuleValidator(rule, eventMock);
 
-      expect(() => validator.checkIfRuleIsOn()).toThrowError('Rule is disabled');
+      expect(() => validator.checkIfRuleIsOn()).toThrowError('rule is disabled');
     });
   });
 
@@ -73,7 +73,7 @@ describe('RuleValidator', () => {
 
       const validator = new RuleValidator(rule, event);
 
-      expect(() => validator.checkWhatToReceive()).toThrowError('Event doesn\'t match `what to receive` filter');
+      expect(() => validator.checkWhatToReceive()).toThrowError('event doesn\'t match `what to receive` filter');
     });
   });
 
@@ -113,7 +113,7 @@ describe('RuleValidator', () => {
 
       const validator = new RuleValidator(rule, event);
 
-      expect(() => validator.checkIncludingWords()).toThrowError('Event title doesn\'t include required words');
+      expect(() => validator.checkIncludingWords()).toThrowError('event title doesn\'t include required words');
     });
   });
 
@@ -140,7 +140,7 @@ describe('RuleValidator', () => {
 
       const validator = new RuleValidator(rule, event);
 
-      expect(() => validator.checkExcludingWords()).toThrowError('Event title includes unwanted words');
+      expect(() => validator.checkExcludingWords()).toThrowError('event title includes unwanted words');
     });
 
     it('should pass if words list is empty', () => {

--- a/workers/sender/src/index.ts
+++ b/workers/sender/src/index.ts
@@ -186,6 +186,8 @@ export default abstract class SenderWorker extends Worker {
       notificationType = 'several-events';
     }
 
+    this.logger.info(`Sending ${notificationType} notification to ${channel.endpoint}`);
+
     this.provider.send(channel.endpoint, {
       type: notificationType,
       payload: {

--- a/workers/telegram/src/provider.ts
+++ b/workers/telegram/src/provider.ts
@@ -19,7 +19,7 @@ export default class TelegramProvider extends NotificationsProvider {
 
     switch (notification.type) {
       case 'event': template = templates.EventTpl; break;
-      case 'several-events':template = templates.SeveralEventsTpl; break;
+      case 'several-events': template = templates.SeveralEventsTpl; break;
       /**
        * @todo add assignee notification for telegram provider
        */


### PR DESCRIPTION
## Changes
- Added verbose logs to notifier's rule validator (also small changes in errors thrown in validator)
- Update related validator tests
- Removed duplicated logic from notifier (double checking of `rule.isEnabled`)
- Added verbose log to sender worker (it would be extender by telegram / slack / email workers)
- Small style fix in telegram provider