### PR TITLE
fix(notifier): fix cache usage

### DIFF
--- a/lib/utils/time.ts
+++ b/lib/utils/time.ts
@@ -2,17 +2,17 @@
 /**
  * Time intervals in ms
  */
-export default class Time {
+export default class TimeMs {
   /** The smallest time interval */
   public static MILLISECOND = 1;
 
-  public static SECOND = Time.MILLISECOND * 1000;
+  public static SECOND = TimeMs.MILLISECOND * 1000;
 
-  public static MINUTE = Time.SECOND * 60;
+  public static MINUTE = TimeMs.SECOND * 60;
 
-  public static HOUR = Time.MINUTE * 60;
+  public static HOUR = TimeMs.MINUTE * 60;
 
-  public static DAY = Time.HOUR * 24;
+  public static DAY = TimeMs.HOUR * 24;
 
-  public static WEEK = Time.DAY * 7;
+  public static WEEK = TimeMs.DAY * 7;
 }

--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -260,6 +260,7 @@ export default class GrouperWorker extends Worker {
     /**
      * Time class stores time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
      */
+    /* eslint-disable-next-line @typescript-eslint/no-magic-numbers */
     Time.MINUTE / 1000);
   }
 

--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -15,7 +15,7 @@ import { MS_IN_SEC } from '../../../lib/utils/consts';
 import DataFilter from './data-filter';
 import RedisHelper from './redisHelper';
 import levenshtein from 'js-levenshtein';
-import Time from '../../../lib/utils/time';
+import TimeMs from '../../../lib/utils/time';
 
 /**
  * Error code of MongoDB key duplication error
@@ -258,10 +258,10 @@ export default class GrouperWorker extends Worker {
         .toArray();
     },  
     /**
-     * Time class stores time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
+     * TimeMs class stores time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
      */
     /* eslint-disable-next-line @typescript-eslint/no-magic-numbers */
-    Time.MINUTE / 1000);
+    TimeMs.MINUTE / 1000);
   }
 
   /**

--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -15,6 +15,7 @@ import { MS_IN_SEC } from '../../../lib/utils/consts';
 import DataFilter from './data-filter';
 import RedisHelper from './redisHelper';
 import levenshtein from 'js-levenshtein';
+import Time from '../../../lib/utils/time';
 
 /**
  * Error code of MongoDB key duplication error
@@ -246,8 +247,6 @@ export default class GrouperWorker extends Worker {
    * @param count - how many events to return
    */
   private findLastEvents(projectId: string, count): Promise<GroupedEventDBScheme[]> {
-    const msInOneMinute = 60000;
-
     return this.cache.get(`last:${count}:eventsOf:${projectId}`, async () => {
       return this.db.getConnection()
         .collection(`events:${projectId}`)
@@ -257,7 +256,11 @@ export default class GrouperWorker extends Worker {
         })
         .limit(count)
         .toArray();
-    }, msInOneMinute);
+    },  
+    /**
+     * Time class stores time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
+     */
+    Time.MINUTE / 1000);
   }
 
   /**

--- a/workers/notifier/src/index.ts
+++ b/workers/notifier/src/index.ts
@@ -114,7 +114,7 @@ export default class NotifierWorker extends Worker {
           return this.getProjectNotificationRules(projectId);
         },
         /**
-         * Time class stored time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
+         * Time class stores time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
          */
         Time.MINUTE / 1000
       );

--- a/workers/notifier/src/index.ts
+++ b/workers/notifier/src/index.ts
@@ -116,6 +116,7 @@ export default class NotifierWorker extends Worker {
         /**
          * Time class stores time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
          */
+        /* eslint-disable-next-line @typescript-eslint/no-magic-numbers */
         Time.MINUTE / 1000
       );
     } catch (e) {

--- a/workers/notifier/src/index.ts
+++ b/workers/notifier/src/index.ts
@@ -113,7 +113,10 @@ export default class NotifierWorker extends Worker {
         () => {
           return this.getProjectNotificationRules(projectId);
         },
-        Time.MINUTE
+        /**
+         * Time class stored time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
+         */
+        Time.MINUTE / 1000
       );
     } catch (e) {
       this.logger.warn('Failed to get project notification rules because ', e);

--- a/workers/notifier/src/index.ts
+++ b/workers/notifier/src/index.ts
@@ -9,7 +9,7 @@ import { NotifierEvent, NotifierWorkerTask } from '../types/notifier-task';
 import { Rule, WhatToReceive } from '../types/rule';
 import { SenderWorkerTask } from 'hawk-worker-sender/types/sender-task';
 import RuleValidator from './validator';
-import Time from '../../../lib/utils/time';
+import TimeMs from '../../../lib/utils/time';
 import RedisHelper from './redisHelper';
 
 /**
@@ -114,10 +114,10 @@ export default class NotifierWorker extends Worker {
           return this.getProjectNotificationRules(projectId);
         },
         /**
-         * Time class stores time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
+         * TimeMs class stores time intervals in milliseconds, however NodeCache ttl needs to be specified in seconds
          */
         /* eslint-disable-next-line @typescript-eslint/no-magic-numbers */
-        Time.MINUTE / 1000
+        TimeMs.MINUTE / 1000
       );
     } catch (e) {
       this.logger.warn('Failed to get project notification rules because ', e);

--- a/workers/sender/src/index.ts
+++ b/workers/sender/src/index.ts
@@ -12,7 +12,7 @@ import { DatabaseController } from '../../../lib/db/controller';
 import { Worker } from '../../../lib/worker';
 import * as pkg from '../package.json';
 import './env';
-import Time from '../../../lib/utils/time';
+import TimeMs from '../../../lib/utils/time';
 
 import { PasswordResetNotification, PaymentSuccessNotification, TemplateEventData, WorkspaceInviteNotification } from '../types/template-variables/';
 import NotificationsProvider from './provider';
@@ -307,7 +307,7 @@ export default abstract class SenderWorker extends Worker {
     /**
      * Send message not often than once per day
      */
-    const throttleInterval = Time.DAY;
+    const throttleInterval = TimeMs.DAY;
 
     const { workspaceId, daysLeft } = task.payload;
 
@@ -375,7 +375,7 @@ export default abstract class SenderWorker extends Worker {
     /**
      * Send message not often than once per day
      */
-    const throttleInterval = Time.DAY;
+    const throttleInterval = TimeMs.DAY;
 
     const { workspaceId, eventsCount, eventsLimit } = task.payload;
 


### PR DESCRIPTION
## Problem
Now we are using `Time.MINUTE` constant as ttl for `NodeCache.set` time limit parameter
`Time.MINUTE` stores time in milliseconds, however `NodeCache.set` requires ttl in seconds
This is why cache is not updated for 1000 minutes ~ 17 hrs, so rules are updated from db with 17 hrs delay

## Change
Pass `Time.MINUTE / 1000` to pass ttl in seconds

## Changed workers
- Notifier
- Grouper