### PR TITLE
Feat: Add performance worker to process 'performance' queue and save data to MongoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .DS_Store
 globalConfig.json
 *.log
+.history

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
         "run-release": "yarn worker hawk-worker-release",
         "run-email": "yarn worker hawk-worker-email",
         "run-telegram": "yarn worker hawk-worker-telegram",
-        "run-limiter": "yarn worker hawk-worker-limiter"
+        "run-limiter": "yarn worker hawk-worker-limiter",
+        "run-performance": "yarn worker hawk-worker-performance"
     },
     "dependencies": {
         "@hawk.so/nodejs": "^3.1.1",

--- a/workers/performance/README.md
+++ b/workers/performance/README.md
@@ -1,0 +1,63 @@
+# Performance worker
+
+This worker is needed to save performance data uploaded from user to our DB. 
+
+## Performance delivery scheme
+
+1. User wants to deploy project
+2. He runs deploy script on the server and it runs static builder, for example Webpack.
+3. After Webpack finished his job, our [Webpack Plugin](https://github.com/codex-team/hawk.webpack.plugin) gets a source maps for new bundles and sends them to us.
+
+example request:
+
+```bash
+curl --location 'http://localhost:3000/performance' \
+--header 'Content-Type: application/json' \
+--data '{
+    "token": "eyJpbnRlZ3JhdGlvbklkIjoiZTU2ZTU5ODctN2JhZi00NTI3LWI4MmMtYjdkOWRhZDBiMDBmIiwic2VjcmV0IjoiZDQ5YTU0YjMtOWExZi00ZGI2LTkxZmYtMjk4M2JlMTVlODA0In0=",
+  "projectId": "67d4adeccf25fa00ab563c32",
+  "catcherType": "performance",
+  "payload": {
+    "projectId": "67d4adeccf25fa00ab563c32",
+    "transactionId": "drxEFnbxGc7OumTVl3FkCm1v9BvBC9OpBrEiE3qG",
+    "name": "complex-operation",
+    "timestamp": 1742075217,
+    "duration": 702.9999999999964,
+    "startTime": 15322.000000000002,
+    "endTime": 16024.999999999998,
+    "catcherVersion": "3.2.1",
+    "spans": [
+      {
+        "id": "6tk2UD4m0wDUjD99uvO1wylp3SnYumiWPlhRCZ2w",
+        "name": "step-1",
+        "duration": 400.9999999999982,
+        "startTime": 15322.000000000002,
+        "endTime": 15723,
+        "transactionId": "drxEFnbxGc7OumTVl3FkCm1v9BvBC9OpBrEiE3qG"
+      },
+      {
+        "id": "V2ZOiUWjtip5ZSATIr7VX4KInAZgGJxdUQNZot2j",
+        "name": "step-2",
+        "duration": 301.9999999999982,
+        "startTime": 15723,
+        "endTime": 16024.999999999998,
+        "transactionId": "drxEFnbxGc7OumTVl3FkCm1v9BvBC9OpBrEiE3qG"
+      },
+      {
+        "id": "JGIerBJqInvnvpIPBwsUIfuIxt3LcWQ6lFPwQJdN",
+        "name": "step-3",
+        "duration": 300.9999999999982,
+        "startTime": 15724,
+        "endTime": 16024.999999999998,
+        "transactionId": "drxEFnbxGc7OumTVl3FkCm1v9BvBC9OpBrEiE3qG"
+      }
+    ],
+    "tags": {
+      "type": "background"
+    }
+  }
+}'
+```
+
+4. Collector accepts file and give a task for PerformanceWorker for saving it to DB
+5. PerformanceWorker saves it to DB.

--- a/workers/performance/package.json
+++ b/workers/performance/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hawk-worker-performance",
+  "description": "Collects and parses performance",
+  "workerType": "performance",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "repository": "https://github.com/codex-team/hawk.workers/tree/master/workers/performance",
+  "author": "CodeX",
+  "license": "UNLICENSED",
+  "private": true,
+  "devDependencies": {
+    "rimraf": "^3.0.0",
+    "webpack": "^4.39.3"
+  }
+}

--- a/workers/performance/src/index.ts
+++ b/workers/performance/src/index.ts
@@ -19,7 +19,7 @@ export default class PerformanceWorker extends Worker {
    */
   private db: DatabaseController = new DatabaseController(process.env.MONGO_EVENTS_DATABASE_URI);
 
-  private readonly dbCollectionName: string = 'performance';
+  private readonly dbCollectionName: string = 'performance_transactions';
   private readonly dbSpansCollectionName: string = 'performance_spans';
   /**
    * Collection to save performance data

--- a/workers/performance/src/index.ts
+++ b/workers/performance/src/index.ts
@@ -1,0 +1,100 @@
+import { DatabaseController } from '../../../lib/db/controller';
+import { Worker } from '../../../lib/worker';
+import { DatabaseReadWriteError } from '../../../lib/workerErrors';
+import * as pkg from '../package.json';
+import { Collection } from 'mongodb';
+import type { PerformanceRecord, PerformanceDocument, PerformanceSpansDocument } from './types';
+
+/**
+ * Performance worker
+ */
+export default class PerformanceWorker extends Worker {
+  /**
+   * Worker type (will pull tasks from Registry queue with the same name)
+   */
+  public readonly type: string = pkg.workerType;
+
+  /**
+   * Database Controller
+   */
+  private db: DatabaseController = new DatabaseController(process.env.MONGO_EVENTS_DATABASE_URI);
+
+  private readonly dbCollectionName: string = 'performance';
+  private readonly dbSpansCollectionName: string = 'performance_spans';
+  /**
+   * Collection to save performance data
+   */
+  private performanceCollection: Collection<PerformanceDocument>;
+
+  /**
+   * Collection to save performance spans
+   */
+  private performanceSpansCollection: Collection<PerformanceSpansDocument>;
+
+  /**
+   * Start consuming messages
+   */
+  public async start(): Promise<void> {
+    await this.db.connect();
+    this.db.createGridFsBucket(this.dbCollectionName);
+    this.performanceCollection = this.db.getConnection().collection(this.dbCollectionName);
+    this.performanceSpansCollection = this.db.getConnection().collection(this.dbSpansCollectionName);
+    await super.start();
+  }
+
+  /**
+   * Finish everything
+   */
+  public async finish(): Promise<void> {
+    await super.finish();
+    await this.db.close();
+  }
+
+  /**
+   * Message handle function
+   *
+   * @param task - Message object from consume method
+   */
+  public async handle(task: PerformanceRecord): Promise<void> {
+    switch (task.catcherType) {
+      case 'performance': await this.savePerformance(task); break;
+    }
+  }
+
+  /**
+   * Save performance data to database
+   *
+   * @param data - Performance record containing project ID and performance metrics
+   */
+  private async savePerformance(data: PerformanceRecord): Promise<void> {
+    try {
+      const { projectId, payload, catcherType } = data;
+
+      if (catcherType !== 'performance') {
+        throw new Error('Invalid catcher type');
+      }
+
+      await Promise.all([
+        this.performanceCollection.insertOne({
+          projectId,
+          transactionId: payload.id,
+          timestamp: payload.timestamp,
+          duration: payload.duration,
+          name: payload.name,
+          catcherVersion: payload.catcherVersion,
+          tags: payload.tags,
+        }),
+        this.performanceSpansCollection.insertMany(
+          payload.spans.map(span => ({
+            projectId,
+            timestamp: payload.timestamp,
+            ...span,
+          }))
+        ),
+      ]);
+    } catch (err) {
+      this.logger.error(`Couldn't save the release due to: ${err}`);
+      throw new DatabaseReadWriteError(err);
+    }
+  }
+}

--- a/workers/performance/src/types.ts
+++ b/workers/performance/src/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Interface for time span
+ */
+interface Span {
+  id: string;
+  name: string;
+  duration: number;
+  startTime: number;
+  endTime: number;
+  transactionId: string;
+}
+
+/**
+ * Interface for performance data
+ */
+interface PerformancePayload {
+    id: string;
+    name: string;
+    timestamp: number;
+    duration: number;
+    startTime: number;
+    endTime: number;
+    catcherVersion: string;
+    spans: Span[];
+    tags: {
+        [key: string]: string;
+    };
+}
+
+/**
+ * Main interface for performance record
+ */
+interface PerformanceRecord {
+  projectId: string;
+  payload: PerformancePayload;
+  catcherType: 'performance';
+}
+
+/**
+ * Interface for performance database document
+ */
+interface PerformanceDocument {
+  projectId: string;
+  transactionId: string;
+  timestamp: number;
+  duration: number;
+  name: string;
+  catcherVersion: string;
+  tags: Record<string, string>;
+}
+
+interface PerformanceSpansDocument extends Span {
+  projectId: string;
+  transactionId: string;
+  timestamp: number;
+}
+
+export type {
+  Span,
+  PerformanceRecord,
+  PerformancePayload,
+  PerformanceDocument,
+  PerformanceSpansDocument
+};


### PR DESCRIPTION
•	Added a new worker performance to handle messages from the performance queue.
•	The worker processes incoming performance data and stores it in MongoDB.
•	Data is saved into the performance_transactions and performance_spans collections.