### PR TITLE
imp(notifier): add ttl for redis records

### DIFF
--- a/workers/notifier/src/redisHelper.ts
+++ b/workers/notifier/src/redisHelper.ts
@@ -1,6 +1,7 @@
 import { createClient, RedisClientType } from 'redis';
 import { Rule } from '../types/rule';
 import { NotifierEvent } from '../types/notifier-task';
+import { MS_IN_SEC } from '../../../lib/utils/consts';
 
 /**
  * Class with helper functions for working with Redis
@@ -76,7 +77,7 @@ export default class RedisHelper {
     /**
      * Treshold period is in milliseconds, but redis expects ttl in seconds
      */
-    const ttl = Math.floor(thresholdPeriod / 1000);
+    const ttl = Math.floor(thresholdPeriod / MS_IN_SEC);
 
     const currentTimestamp = Date.now();
 


### PR DESCRIPTION
## Problem
The problem is that we do not delete any of the inserted redis records (related to the notification rules)
this leads to memory leak

## Solution
- Add ttl for every redis key, used for notification counters (ttl equals to the rule thresholdPeriod, when ttl passed, record will be deleted from the redis store)
- Cover expiration with tests