### PR TITLE
chore(sentry): rm breadcrumbs addon

### DIFF
--- a/workers/sentry/package.json
+++ b/workers/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk-worker-sentry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Handles events in Sentry format",
   "main": "src/index.ts",
   "author": "CodeX",

--- a/workers/sentry/src/utils/converter.ts
+++ b/workers/sentry/src/utils/converter.ts
@@ -129,7 +129,6 @@ export function composeAddons(eventPayload: SentryEvent): EventData<DefaultAddon
     'transaction',
     'modules',
     'fingerprint',
-    'breadcrumbs',
     'tags',
     'extra',
   ];

--- a/workers/sentry/tests/converter.test.ts
+++ b/workers/sentry/tests/converter.test.ts
@@ -197,9 +197,6 @@ describe('converter utils', () => {
         transaction: 'test-transaction',
         modules: { key: 'value' },
         fingerprint: [ 'test-fingerprint' ],
-        breadcrumbs: [ {
-          message: 'Test breadcrumb',
-        } ],
         tags: { key: 'value' },
         extra: { key: 'value' },
       });

--- a/workers/sentry/tests/index.test.ts
+++ b/workers/sentry/tests/index.test.ts
@@ -775,9 +775,6 @@ describe('SentryEventWorker', () => {
             },
           },
           addons: {
-            breadcrumbs: {
-              values: [],
-            },
             environment: 'production',
             platform: 'python',
             extra: {


### PR DESCRIPTION
The `breadcrumbs` add-on has been removed for Sentry events because it looks like very big and unusable JSON.

If we need this feature, it should be supported by Hawk first.