### PR TITLE
fix(release): release worker dies

### DIFF
--- a/workers/release/src/index.ts
+++ b/workers/release/src/index.ts
@@ -179,16 +179,22 @@ export default class ReleaseWorker extends Worker {
             const fileInfo = await this.saveFile(map);
 
             /**
-             * Remove 'content' and save id of saved file instead
+             * Save id of saved file instead
              */
             map._id = fileInfo._id;
-            delete map.content;
 
             return map;
           } catch (error) {
             this.logger.error(`Map ${map.mapFileName} was not saved: ${error}`);
           }
         }));
+
+        /**
+         * Delete file content after it is saved to the GridFS
+         */
+        savedFiles.forEach(file => {
+          delete file.content;
+        })
 
         /**
          * Filter unsaved maps

--- a/workers/release/src/index.ts
+++ b/workers/release/src/index.ts
@@ -282,6 +282,10 @@ export default class ReleaseWorker extends Worker {
    */
   private saveFile(file: SourceMapDataExtended): Promise<SourceMapFileChunk> {
     return new Promise((resolve, reject) => {
+      if (!file.content) {
+        return reject(new Error('Source map content is empty'));
+      }
+
       const readable = Readable.from([ file.content ]);
       const writeStream = this.db.getBucket().openUploadStream(file.mapFileName);
 


### PR DESCRIPTION
`file.content` could be undefined because we call delete `map.content` inside of the `Promise.all` just after `await saveFile(map)` - it means that map content deleted before being saved to the gridFs 

in this case `Readable.from([ file.content ])` breaks the worker