### PR TITLE
Fix(grouper): grouping patterns

### DIFF
--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -332,7 +332,7 @@ export default class GrouperWorker extends Worker {
             return originalEvent;
           }
         } catch (e) {
-          this.logger.error(`Error while getting original event for pattern ${matchingPattern}`);
+          this.logger.error(`Error while getting original event for pattern ${matchingPattern}: ${e.message}`);
         }
       }
     }

--- a/workers/grouper/tests/index.test.ts
+++ b/workers/grouper/tests/index.test.ts
@@ -490,7 +490,9 @@ describe('GrouperWorker', () => {
       });
 
       test('should group events with titles matching one pattern', async () => {
-        jest.spyOn(GrouperWorker.prototype as any, 'getProjectPatterns').mockResolvedValue([ 'New error .*' ]);
+        jest.spyOn(GrouperWorker.prototype as any, 'getProjectPatterns').mockResolvedValue([ 
+          { _id: new mongodb.ObjectId, pattern: 'New error .*' }
+        ]);
         const findMatchingPatternSpy = jest.spyOn(GrouperWorker.prototype as any, 'findMatchingPattern');
 
         await worker.handle(generateTask({ title: 'New error 0000000000000000' }));
@@ -507,9 +509,9 @@ describe('GrouperWorker', () => {
 
       test('should handle multiple patterns and match the first one that applies', async () => {
         jest.spyOn(GrouperWorker.prototype as any, 'getProjectPatterns').mockResolvedValue([
-          'Database error: .*',
-          'Network error: .*',
-          'New error: .*',
+          { _id: mongodb.ObjectId(), pattern: 'Database error: .*' },
+          { _id: mongodb.ObjectId(), pattern: 'Network error: .*' },
+          { _id: mongodb.ObjectId(), pattern: 'New error: .*' },
         ]);
 
         await worker.handle(generateTask({ title: 'Database error: connection failed' }));
@@ -526,8 +528,8 @@ describe('GrouperWorker', () => {
 
       test('should handle complex regex patterns', async () => {
         jest.spyOn(GrouperWorker.prototype as any, 'getProjectPatterns').mockResolvedValue([
-          'Error \\d{3}: [A-Za-z\\s]+ in file .*\\.js$',
-          'Warning \\d{3}: .*',
+          { _id: mongodb.ObjectId(), pattern: 'Error \\d{3}: [A-Za-z\\s]+ in file .*\\.js$' },
+          { _id: mongodb.ObjectId(), pattern: 'Warning \\d{3}: .*' },
         ]);
 
         await worker.handle(generateTask({ title: 'Error 404: Not Found in file index.js' }));
@@ -544,8 +546,8 @@ describe('GrouperWorker', () => {
 
       test('should maintain separate groups for different patterns', async () => {
         jest.spyOn(GrouperWorker.prototype as any, 'getProjectPatterns').mockResolvedValue([
-          'TypeError: .*',
-          'ReferenceError: .*',
+          { _id: mongodb.ObjectId(), pattern: 'TypeError: .*' },
+          { _id: mongodb.ObjectId(), pattern: 'ReferenceError: .*' },
         ]);
 
         await worker.handle(generateTask({ title: 'TypeError: null is not an object' }));
@@ -566,8 +568,8 @@ describe('GrouperWorker', () => {
 
       test('should handle patterns with special regex characters', async () => {
         jest.spyOn(GrouperWorker.prototype as any, 'getProjectPatterns').mockResolvedValue([
-          'Error \\[\\d+\\]: .*',
-          'Warning \\(code=\\d+\\): .*',
+          { _id: new mongodb.ObjectID(), pattern: 'Error \\[\\d+\\]: .*'} ,
+          { _id: new mongodb.ObjectID(), pattern: 'Warning \\(code=\\d+\\): .*'} ,
         ]);
 
         await worker.handle(generateTask({ title: 'Error [123]: Database connection failed' }));

--- a/workers/grouper/tests/index.test.ts
+++ b/workers/grouper/tests/index.test.ts
@@ -67,7 +67,7 @@ const projectMock = {
   },
   unreadCount: 0,
   description: 'Test project for grouper worker tests',
-  eventGroupingPatterns: [ 'New error .*' ],
+  eventGroupingPatterns: [ { _id: mongodb.ObjectId(), pattern: 'New error .*' }],
 };
 
 /**


### PR DESCRIPTION
## Problem
- grouping patterns are stored in db in format 

```ts
export interface ProjectEventGroupingPatternsDBScheme {
    /**
     * If of the pattern
     */
    _id: ObjectId;
    /**
     * String that represents regular expression pattern
     */
    pattern: string;
}
```

but we are treating them as `string[]`. That leads to this type of errors:
```
2025-07-17T14:33:40.699Z error: Error while getting original event for pattern [object Object] 
```

- also this issue is invisible for tests because of incorrect grouping patterns mocking (they are mocked as `string[]` as well)

## Solution
- Treat grouping patterns as described in `ProjectEventGroupingPatternsDBScheme` interface (as they actually stored)
- Fix mocks in tests