### PR TITLE
imp(): improve notifier excluding words validation

### DIFF
--- a/workers/notifier/src/validator.ts
+++ b/workers/notifier/src/validator.ts
@@ -112,7 +112,7 @@ export default class RuleValidator {
     if (!excluding.length) {
       result = true;
     } else {
-      result = !excluding.some((word: string) => event.title.toLowerCase().includes(word));
+      result = !excluding.some((word: string) => event.title.toLowerCase().includes(word.toLowerCase()));
     }
 
     if (!result) {


### PR DESCRIPTION
## Problem
- Notifier excluding words validation works unexpectedly, it lowers event title but now lowers excluding word to check