### PR TITLE
fix(): move logs after the conditions

### DIFF
--- a/workers/javascript/src/index.ts
+++ b/workers/javascript/src/index.ts
@@ -342,7 +342,9 @@ export default class JavascriptEventWorker extends EventWorker {
         },
       });
     } catch (traverseError) {
-      console.error(`Failed to parse source code: ${traverseError}`);
+      console.error(`Failed to parse source code:`);
+      console.error(traverseError);
+
       HawkCatcher.send(traverseError);
     }
 


### PR DESCRIPTION
## Problem
- We log some of the path properties before check of their existence, this leads to error

## Solution
- Move logs under the condition
- Send errors to Hawk