### PR TITLE
fix(): fix source-map saving

### DIFF
--- a/workers/javascript/src/index.ts
+++ b/workers/javascript/src/index.ts
@@ -264,6 +264,7 @@ export default class JavascriptEventWorker extends EventWorker {
       const ast = parse(sourceCode, {
         sourceType: 'module',
         plugins: [
+          'jsx',
           'typescript',
           'classProperties',
           'decorators',

--- a/workers/javascript/src/index.ts
+++ b/workers/javascript/src/index.ts
@@ -228,14 +228,20 @@ export default class JavascriptEventWorker extends EventWorker {
      * Fixes bug: https://github.com/codex-team/hawk.workers/issues/121
      */
     if (originalLocation.source) {
-      /**
-       * Get 5 lines above and 5 below
-       */
-      lines = this.readSourceLines(consumer, originalLocation);
+      try {
+        /**
+         * Get 5 lines above and 5 below
+         */
+        lines = this.readSourceLines(consumer, originalLocation);
 
-      const originalContent = consumer.sourceContentFor(originalLocation.source);
+        const originalContent = consumer.sourceContentFor(originalLocation.source);
 
-      functionContext = this.getFunctionContext(originalContent, originalLocation.line) ?? originalLocation.name;
+        functionContext = this.getFunctionContext(originalContent, originalLocation.line) ?? originalLocation.name;
+      } catch(e) {
+        HawkCatcher.send(e);
+        this.logger.error('Can\'t get function context');
+        this.logger.error(e);
+      }
     }
 
     return Object.assign(stackFrame, {

--- a/workers/javascript/src/index.ts
+++ b/workers/javascript/src/index.ts
@@ -233,9 +233,9 @@ export default class JavascriptEventWorker extends EventWorker {
        */
       lines = this.readSourceLines(consumer, originalLocation);
 
-      const _originalContent = consumer.sourceContentFor(originalLocation.source);
+      const originalContent = consumer.sourceContentFor(originalLocation.source);
 
-      // functionContext = this.getFunctionContext(originalContent, originalLocation.line) ?? originalLocation.name;
+      functionContext = this.getFunctionContext(originalContent, originalLocation.line) ?? originalLocation.name;
     }
 
     return Object.assign(stackFrame, {
@@ -254,7 +254,7 @@ export default class JavascriptEventWorker extends EventWorker {
    * @param line - number of the line from the stack trace
    * @returns {string | null} - string of the function context or null if it could not be parsed
    */
-  private _getFunctionContext(sourceCode: string, line: number): string | null {
+  private getFunctionContext(sourceCode: string, line: number): string | null {
     let functionName: string | null = null;
     let className: string | null = null;
     let isAsync = false;
@@ -284,7 +284,7 @@ export default class JavascriptEventWorker extends EventWorker {
         ClassDeclaration(path) {
           if (path.node.loc && path.node.loc.start.line <= line && path.node.loc.end.line >= line) {
             console.log(`class declaration: loc: ${path.node.loc}, line: ${line}, node.start.line: ${path.node.loc.start.line}, node.end.line: ${path.node.loc.end.line}`);
-            
+
             className = path.node.id.name || null;
           }
         },
@@ -297,7 +297,7 @@ export default class JavascriptEventWorker extends EventWorker {
         ClassMethod(path) {
           if (path.node.loc && path.node.loc.start.line <= line && path.node.loc.end.line >= line) {
             console.log(`class declaration: loc: ${path.node.loc}, line: ${line}, node.start.line: ${path.node.loc.start.line}, node.end.line: ${path.node.loc.end.line}`);
-          
+
             // Handle different key types
             if (path.node.key.type === 'Identifier') {
               functionName = path.node.key.name;
@@ -313,7 +313,7 @@ export default class JavascriptEventWorker extends EventWorker {
         FunctionDeclaration(path) {
           if (path.node.loc && path.node.loc.start.line <= line && path.node.loc.end.line >= line) {
             console.log(`function declaration: loc: ${path.node.loc}, line: ${line}, node.start.line: ${path.node.loc.start.line}, node.end.line: ${path.node.loc.end.line}`);
-          
+
             functionName = path.node.id.name || null;
             isAsync = path.node.async;
           }

--- a/workers/release/src/index.ts
+++ b/workers/release/src/index.ts
@@ -162,7 +162,7 @@ export default class ReleaseWorker extends Worker {
         /**
          * Iterate all maps of the new release and save only new
          */
-        let savedFiles = await Promise.all(files.map(async (map: SourceMapDataExtended) => {
+        const savedFiles = await Promise.all(files.map(async (map: SourceMapDataExtended) => {
           /**
            * Skip already saved maps
            */
@@ -194,7 +194,7 @@ export default class ReleaseWorker extends Worker {
          * Filter undefined files and then prepare files that would be saved to releases table
          * we do not need their content since it would be stored in gridFS
          */
-        let savedFilesWithoutContent: Omit<SourceMapDataExtended, 'content'>[] = savedFiles.filter(file => {
+        const savedFilesWithoutContent: Omit<SourceMapDataExtended, 'content'>[] = savedFiles.filter(file => {
           return file !== undefined;
         }).map(({ content, ...rest }) => {
           return rest;


### PR DESCRIPTION
## Problem
<img width="965" height="62" alt="image" src="https://github.com/user-attachments/assets/f8db0bb3-96f7-4b77-85a1-906cce2b7c79" />
- On some saves we had this kind of error related to the transactions
we've implemented transactions in this pr: (https://github.com/codex-team/hawk.workers/pull/390)
so now if some of the transaction is blocked (it will stop and then re-run after db lock will be removed) but in js we already mutated savedFile object (we used `delete file.content;` and it led to errors on transaction re-run)

## Solution
- do not mutate original savedFiles object to avoid errors on transaction re-run