### PR TITLE
fix(grouper): skip notifications for muted errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     },
     "dependencies": {
         "@hawk.so/nodejs": "^3.1.1",
-        "@hawk.so/types": "^0.1.32",
+        "@hawk.so/types": "^0.1.35",
         "@types/amqplib": "^0.8.2",
         "@types/jest": "^29.2.3",
         "@types/mongodb": "^3.5.15",

--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -235,9 +235,7 @@ export default class GrouperWorker extends Worker {
      * Add task for NotifierWorker only if event is not ignored
      */
     if (process.env.IS_NOTIFIER_WORKER_ENABLED) {
-      const isIgnored = isFirstOccurrence
-        ? false
-        : !!(existedEvent as GroupedEventDBScheme & { marks?: { ignored?: boolean } })?.marks?.ignored;
+      const isIgnored = isFirstOccurrence ? false : !!existedEvent?.marks?.ignored;
 
       if (!isIgnored) {
         await this.addTask(WorkerNames.NOTIFIER, {

--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -237,8 +237,7 @@ export default class GrouperWorker extends Worker {
     if (process.env.IS_NOTIFIER_WORKER_ENABLED) {
       const isIgnored = isFirstOccurrence
         ? false
-        : !!(existedEvent as GroupedEventDBScheme & { marks?: { ignored?: boolean } })?.marks
-            ?.ignored;
+        : !!(existedEvent as GroupedEventDBScheme & { marks?: { ignored?: boolean } })?.marks?.ignored;
 
       if (!isIgnored) {
         await this.addTask(WorkerNames.NOTIFIER, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,10 +428,10 @@
   dependencies:
     "@types/mongodb" "^3.5.34"
 
-"@hawk.so/types@^0.1.32":
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/@hawk.so/types/-/types-0.1.32.tgz#5eb662e91da922e1cbab7af0cf03bfa567ee98df"
-  integrity sha512-7gdx/fq31iLxmc0hZKs+wPYqtRT4rLvTi9p4am2My9SQ4t/l8if5QEfxh6G4WABKOmhiZLchivFA9Oj+Nn5EcQ==
+"@hawk.so/types@^0.1.35":
+  version "0.1.35"
+  resolved "https://registry.yarnpkg.com/@hawk.so/types/-/types-0.1.35.tgz#6afd416dced1cc3282d721ca5621bf452b27aea1"
+  integrity sha512-uMTAeu6DlRlk+oputJBjTlrm1GzOkIwlMfGhpdOp3sRWe/YPGD6nMYlb9MZoVN6Yee7RIpYD7It+DPeUPAyIFw==
   dependencies:
     "@types/mongodb" "^3.5.34"
 
@@ -4628,11 +4628,6 @@ jest@^29.2.2:
     "@jest/types" "^29.6.3"
     import-local "^3.0.2"
     jest-cli "^29.7.0"
-
-js-levenshtein@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
-  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 js-tokens@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4629,6 +4629,11 @@ jest@^29.2.2:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
* Implemented a new method to check if an event is marked as ignored.
* Add task for NotifierWorker only if event is not ignored

Resolves #423