### PR TITLE
chore(release): check mapContent file field

### DIFF
--- a/workers/release/src/index.ts
+++ b/workers/release/src/index.ts
@@ -278,7 +278,12 @@ export default class ReleaseWorker extends Worker {
 
       return [ {
         mapFileName: file.name,
-        originFileName: mapContent.file,
+        /**
+         * Some bundlers could skip file in the source map content since it duplicates in map name
+         * Like map name bundle.js.map is a source map for a bundle.js
+         * @see https://sourcemaps.info/spec.html - format
+         */
+        originFileName: mapContent.file ?? file.name.replace(/\.map$/, ''),
         content: mapBodyString,
       } ];
     });


### PR DESCRIPTION
## Problem 
according to source-map 3 spec 
File: An optional name of the generated code that this source map is associated with.
And we rely on an optional field

## Solution
if `mapContent.file` is not defined — use stripped version of the map filename
e.g. for `bundle.js.map` we would have `bundle.js` as an `originFileName`