### PR TITLE
chore(tests): fix test speed

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,4 +28,6 @@ module.exports = {
   setupFiles: [ './jest.setup.js' ],
 
   setupFilesAfterEnv: ['./jest.setup.redis-mock.js', './jest.setup.mongo-repl-set.js'],
+  
+  globalTeardown: './jest.global-teardown.js',
 };

--- a/jest.global-teardown.js
+++ b/jest.global-teardown.js
@@ -1,0 +1,9 @@
+const process = require('process');
+
+module.exports = () => {
+  if (process.env.CI) {
+    setTimeout(() => {
+      process.exit(0);
+    }, 1000);
+  }
+}

--- a/jest.setup.mongo-repl-set.js
+++ b/jest.setup.mongo-repl-set.js
@@ -28,15 +28,15 @@ beforeAll(async () => {
      * Wait for the replica set to initialize all nodes
      */
     do {
-      await new Promise(resolve => setTimeout(resolve, 1000));
       status = await admin.command({ replSetGetStatus: 1 });
 
       const primary = status.members.find(member => member.stateStr === 'PRIMARY');
-      const secondary = status.members.find(member => member.stateStr === 'SECONDARY');
 
-      if (primary && secondary) {
+      if (primary) {
         break;
       }
+
+      await new Promise(resolve => setTimeout(resolve, 1000));
     } while (Date.now() - startTime < timeout);
 
     console.log('✅ Replica set is stable');


### PR DESCRIPTION
check out tests workflow (\~1m) ( ͡~ ͜ʖ ͡°)

### Changes
#### Archiver
- use cursor based db fetch to avoid all projects storing in memory
- use projection to retrieve only fields that are needed
- axios (notifications) could return nothing env hook configured poorly — worker should not fail in this case

#### Tests
- do not await `SECONDARY` mongo node initialisation (since we don't have one)
- exit node.js process after tests are done to avoid open handles and infinite CI run (exit only in CI so we could debug open handles locally whenever we want)