### PR TITLE
Fix: Improve quota notification and blocking logic

### DIFF
--- a/workers/limiter/src/index.ts
+++ b/workers/limiter/src/index.ts
@@ -291,6 +291,7 @@ export default class LimiterWorker extends Worker {
       /**
        * Notify that workspace is about to reach events limit
        */
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       this.logger.info(`Workspace ${workspace._id} is about to reach events limit: ${Math.floor(usedQuota * 100)}% used`);
 
       /**


### PR DESCRIPTION
Problem: I still get mails about near limits, but workspace is already blocked.

<img width="364" height="246" alt="image" src="https://github.com/user-attachments/assets/a277569a-f4c7-475a-bbc2-3f3decda347e" />

<img width="547" height="568" alt="Screenshot 2025-12-08 at 17 19 35" src="https://github.com/user-attachments/assets/87a607d3-bf13-4b80-ac6e-c9613f44b868" />


Refactored the quota check to ensure workspaces are blocked and notified only when appropriate. Added logging for both blocking and approaching quota limits, and clarified notification task handling.