### PR TITLE
Add webhook sender worker to production docker-compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -84,3 +84,11 @@ services:
       - workers/telegram/.env
     restart: unless-stopped
     entrypoint: /usr/local/bin/node runner.js hawk-worker-telegram
+
+  hawk-worker-webhook:
+    image: "codexteamuser/hawk-workers:prod"
+    network_mode: host
+    env_file:
+      - .env
+    restart: unless-stopped
+    entrypoint: /usr/local/bin/node runner.js hawk-worker-webhook


### PR DESCRIPTION
## Description:
- Add missing hawk-worker-webhook service to docker-compose.prod.yml — webhook notifications were never consumed because the container was not defined in the production compose file