### PR TITLE
fix(): redis never throws key does not exist

### DIFF
--- a/workers/grouper/src/redisHelper.ts
+++ b/workers/grouper/src/redisHelper.ts
@@ -193,17 +193,11 @@ export default class RedisHelper {
   ): Promise<void> {
     const timestamp = Date.now();
 
-    try {
-      await this.tsIncrBy(key, value, timestamp, labels);
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('TSDB: key does not exist')) {
-        this.logger.warn(`TS key ${key} does not exist, creating it...`);
-        await this.tsCreateIfNotExists(key, labels, retentionMs);
-        await this.tsIncrBy(key, value, timestamp, labels);
-      } else {
-        throw error;
-      }
-    }
+    /**
+     * Create key if not exists — then call increment
+     */
+    await this.tsCreateIfNotExists(key, labels, retentionMs);
+    await this.tsIncrBy(key, value, timestamp, labels);
   }
 
   /**
@@ -252,17 +246,11 @@ export default class RedisHelper {
   ): Promise<void> {
     const timestamp = Date.now();
 
-    try {
-      await this.tsAdd(key, value, timestamp, labels);
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('TSDB: key does not exist')) {
-        this.logger.warn(`TS key ${key} does not exist, creating it...`);
-        await this.tsCreateIfNotExists(key, labels, retentionMs);
-        await this.tsAdd(key, value, timestamp, labels);
-      } else {
-        throw error;
-      }
-    }
+    /**
+     * Create key if not exists — then call increment
+     */
+    await this.tsCreateIfNotExists(key, labels, retentionMs);
+    await this.tsAdd(key, value, timestamp, labels);
   }
 
   /**


### PR DESCRIPTION
## Issue

In redis time series keys were created without retention — that leads to memory leaks, since keys are never archived

## Cause

from redis docs

> Notes:
> When specified key does not exist, a new time series is created.

so when we called `tsAdd` method and waited for `TSDB: key does not exist` error we did it wrong

it never fires an error, but it automatically creates the key with retention 0 as we saw on stage

## Solution

first — create key if not exists
second — increment key that was created with valid retention in the previous step 