### PR TITLE
perf(paymaster): batch subscription check over workspaces

### DIFF
--- a/workers/paymaster/src/index.ts
+++ b/workers/paymaster/src/index.ts
@@ -232,15 +232,12 @@ export default class PaymasterWorker extends Worker {
 
     let batch: WorkspaceDBScheme[] = [];
 
-    const flush = async (): Promise<void> => {
-      if (batch.length === 0) {
+    const flush = async (currentBatch: WorkspaceDBScheme[]): Promise<void> => {
+      if (currentBatch.length === 0) {
         return;
       }
 
-      const current = batch;
-
-      batch = [];
-      await Promise.all(current.map((workspace) => this.processWorkspaceSubscriptionCheck(workspace)));
+      await Promise.all(currentBatch.map((workspace) => this.processWorkspaceSubscriptionCheck(workspace)));
     };
 
     try {
@@ -258,11 +255,12 @@ export default class PaymasterWorker extends Worker {
         batch.push(workspace);
 
         if (batch.length >= WORKSPACE_PROCESSING_CONCURRENCY) {
-          await flush();
+          await flush(batch);
+          batch = [];
         }
       }
 
-      await flush();
+      await flush(batch);
     } finally {
       await cursor.close();
     }

--- a/workers/paymaster/src/index.ts
+++ b/workers/paymaster/src/index.ts
@@ -35,6 +35,33 @@ const DAYS_LEFT_ALERT = [3, 2, 1];
 const DAYS_AFTER_BLOCK_TO_REMIND = [1, 2, 3, 5, 7, 30];
 
 /**
+ * Bounds concurrent updateOne / addTask calls per subscription check tick.
+ */
+const WORKSPACE_PROCESSING_CONCURRENCY = 25;
+
+const WORKSPACE_CURSOR_BATCH_SIZE = 200;
+
+/**
+ * Keep in sync with fields read by `processWorkspaceSubscriptionCheck` and its helpers.
+ */
+const WORKSPACE_SUBSCRIPTION_PROJECTION = {
+  _id: 1,
+  name: 1,
+  tariffPlanId: 1,
+  lastChargeDate: 1,
+  paidUntil: 1,
+  isDebug: 1,
+  isBlocked: 1,
+  blockedDate: 1,
+  subscriptionId: 1,
+} as const;
+
+const PLAN_PROJECTION = {
+  _id: 1,
+  monthlyCharge: 1,
+} as const;
+
+/**
  * Worker to check workspaces subscription status and ban workspaces without actual subscription
  */
 export default class PaymasterWorker extends Worker {
@@ -151,7 +178,10 @@ export default class PaymasterWorker extends Worker {
       throw new Error('Plans collection is not initialized');
     }
 
-    this.plans = await this.plansCollection.find({}).toArray();
+    this.plans = await this.plansCollection
+      .find({})
+      .project<PlanDBScheme>(PLAN_PROJECTION)
+      .toArray();
 
     if (this.plans.length === 0) {
       throw new Error('Please add tariff plans to the database');
@@ -195,28 +225,47 @@ export default class PaymasterWorker extends Worker {
    * Called periodically, enumerate through workspaces and check if today is a payday for workspace subscription
    */
   private async handleWorkspaceSubscriptionCheckEvent(): Promise<void> {
-    const workspaces = await this.workspaces.find({}).toArray();
+    const cursor = this.workspaces
+      .find({})
+      .project<WorkspaceDBScheme>(WORKSPACE_SUBSCRIPTION_PROJECTION)
+      .batchSize(WORKSPACE_CURSOR_BATCH_SIZE);
 
-    await Promise.all(workspaces
-      .filter(workspace => {
+    let batch: WorkspaceDBScheme[] = [];
+
+    const flush = async (): Promise<void> => {
+      if (batch.length === 0) {
+        return;
+      }
+
+      const current = batch;
+
+      batch = [];
+      await Promise.all(current.map((workspace) => this.processWorkspaceSubscriptionCheck(workspace)));
+    };
+
+    try {
+      for await (const workspace of cursor) {
         /**
          * Skip workspace without lastChargeDate
          */
         if (!workspace.lastChargeDate) {
-          const error = new Error('[Paymaster] Workspace without lastChargeDate detected');
-
-          HawkCatcher.send(error, {
+          HawkCatcher.send(new Error('[Paymaster] Workspace without lastChargeDate detected'), {
             workspaceId: workspace._id.toString(),
           });
-
-          return false;
+          continue;
         }
 
-        return true;
-      })
-      .map(
-        (workspace) => this.processWorkspaceSubscriptionCheck(workspace)
-      ));
+        batch.push(workspace);
+
+        if (batch.length >= WORKSPACE_PROCESSING_CONCURRENCY) {
+          await flush();
+        }
+      }
+
+      await flush();
+    } finally {
+      await cursor.close();
+    }
   }
 
   /**

--- a/workers/paymaster/tests/index.test.ts
+++ b/workers/paymaster/tests/index.test.ts
@@ -794,6 +794,54 @@ describe('PaymasterWorker', () => {
     MockDate.reset();
   });
 
+  test('Should process every workspace when there are several batches', async () => {
+    /**
+     * 50 > WORKSPACE_PROCESSING_CONCURRENCY (25), so the subscription check
+     * has to flush more than one batch.
+     */
+    const WORKSPACES_COUNT = 50;
+    const currentDate = new Date('2005-12-22');
+    const plan = createPlanMock({
+      monthlyCharge: 0,
+      isDefault: true,
+    });
+
+    const workspaces = Array.from({ length: WORKSPACES_COUNT }, () =>
+      createWorkspaceMock({
+        plan,
+        subscriptionId: null,
+        lastChargeDate: new Date('2005-11-22'),
+        isBlocked: false,
+        billingPeriodEventsCount: 0,
+      })
+    );
+
+    await tariffCollection.insertOne(plan);
+    await workspacesCollection.insertMany(workspaces);
+
+    MockDate.set(currentDate);
+
+    const worker = new PaymasterWorker();
+    const processSpy = jest
+      .spyOn(worker as any, 'processWorkspaceSubscriptionCheck')
+      .mockResolvedValue([null, false]);
+
+    await worker.start();
+    await worker.handle(WORKSPACE_SUBSCRIPTION_CHECK);
+    await worker.finish();
+
+    expect(processSpy).toHaveBeenCalledTimes(WORKSPACES_COUNT);
+
+    const calledIds = processSpy.mock.calls
+      .map((call) => (call[0] as WorkspaceDBScheme)._id.toString())
+      .sort();
+    const expectedIds = workspaces.map((w) => w._id.toString()).sort();
+
+    expect(calledIds).toEqual(expectedIds);
+
+    MockDate.reset();
+  });
+
   afterAll(async () => {
     await connection.close();
     MockDate.reset();


### PR DESCRIPTION
Replaces find({}).toArray() over hawk.workspaces with a projected cursor processed in batches of 25. fetchPlans gets a projection too.