### PR TITLE
perf(notifier): project only notifications field when loading rules

### DIFF
--- a/workers/notifier/src/index.ts
+++ b/workers/notifier/src/index.ts
@@ -193,9 +193,12 @@ export default class NotifierWorker extends Worker {
    */
   private async getProjectNotificationRules(projectId: string): Promise<Rule[]> {
     const connection = this.accountsDb.getConnection();
-    const projects = connection.collection('projects');
+    const projects = connection.collection<{ notifications?: Rule[] }>('projects');
 
-    const project = await projects.findOne({ _id: new ObjectID(projectId) });
+    const project = await projects.findOne(
+      { _id: new ObjectID(projectId) },
+      { projection: { notifications: 1 } }
+    );
 
     if (!project) {
       throw new Error('There is no project with given id');

--- a/workers/notifier/tests/worker.test.ts
+++ b/workers/notifier/tests/worker.test.ts
@@ -242,7 +242,10 @@ describe('NotifierWorker', () => {
 
       await worker.handle(message);
 
-      expect(dbQueryMock).toBeCalledWith({ _id: new ObjectID(message.projectId) });
+      expect(dbQueryMock).toBeCalledWith(
+        { _id: new ObjectID(message.projectId) },
+        { projection: { notifications: 1 } }
+      );
     });
 
     it('should close db connection on finish', async () => {


### PR DESCRIPTION
findOne over hawk.projects in notifier now requests only the notifications field instead of the whole project document.