### PR TITLE
Imp(limiter): fetch workspaces with cursor

### DIFF
--- a/workers/limiter/src/dbHelper.ts
+++ b/workers/limiter/src/dbHelper.ts
@@ -35,22 +35,22 @@ export class DbHelper {
   }
 
   /**
-   * Method that returns all workspaces with their tariff plans
+   * Method that yields all workspaces with their tariff plans
    */
-  public async getWorkspacesWithTariffPlans():Promise<WorkspaceWithTariffPlan[]>;
+  public getWorkspacesWithTariffPlans(): AsyncGenerator<WorkspaceWithTariffPlan>;
   /**
    * Method that returns workspace with its tariff plan by its id
    *
    * @param id - id of the workspace to fetch
    */
-  public async getWorkspacesWithTariffPlans(id: string):Promise<WorkspaceWithTariffPlan>;
+  public async getWorkspacesWithTariffPlans(id: string): Promise<WorkspaceWithTariffPlan>;
   /**
    * Returns workspace with its tariff plan by its id
    *
    * @param id - workspace id
    */
-  public async getWorkspacesWithTariffPlans(id?: string):Promise<WorkspaceWithTariffPlan[] | WorkspaceWithTariffPlan> {
-    /* eslint-disable-next-line */
+  public async *getWorkspacesWithTariffPlans(id?: string): AsyncGenerator<WorkspaceWithTariffPlan> | Promise<WorkspaceWithTariffPlan> {
+  /* eslint-disable-next-line */
     const queue: any[] = [
       {
         $lookup: {
@@ -75,9 +75,15 @@ export class DbHelper {
       });
     }
 
-    const workspacesArray = await this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(queue).toArray();
+    const workspaces = this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(queue);
 
-    return (id !== undefined) ? workspacesArray[0] : workspacesArray;
+    if (id !== undefined) {
+      return await workspaces.next();
+    }
+
+    for await (const workspace of workspaces) {
+      yield workspace;
+    }
   }
 
   /**

--- a/workers/limiter/src/dbHelper.ts
+++ b/workers/limiter/src/dbHelper.ts
@@ -43,15 +43,48 @@ export class DbHelper {
    *
    * @param id - id of the workspace to fetch
    */
-  public async getWorkspacesWithTariffPlans(id: string): Promise<WorkspaceWithTariffPlan>;
+  public getWorkspacesWithTariffPlans(id: string): Promise<WorkspaceWithTariffPlan>;
+  public getWorkspacesWithTariffPlans(id?: string): AsyncGenerator<WorkspaceWithTariffPlan> | Promise<WorkspaceWithTariffPlan> {
+    if (id !== undefined) {
+      return this.getOneWorkspaceWithTariffPlan(id);
+    }
+
+    return this.yieldWorkspacesWithTariffPlans();
+  }
+
   /**
-   * Returns workspace with its tariff plan by its id
+   * Returns a single workspace with its tariff plan by id
    *
    * @param id - workspace id
    */
-  public async *getWorkspacesWithTariffPlans(id?: string): AsyncGenerator<WorkspaceWithTariffPlan> | Promise<WorkspaceWithTariffPlan> {
+  private async getOneWorkspaceWithTariffPlan(id: string): Promise<WorkspaceWithTariffPlan> {
+    const pipeline = [
+      {
+        $match: {
+          _id: new ObjectId(id),
+        },
+      },
+      ...this.tariffPlanLookupPipeline(),
+    ];
+
+    return this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(pipeline).next();
+  }
+
+  /**
+   * Yields all workspaces with their tariff plans one by one
+   */
+  private async *yieldWorkspacesWithTariffPlans(): AsyncGenerator<WorkspaceWithTariffPlan> {
+    const pipeline = this.tariffPlanLookupPipeline();
+    const cursor = this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(pipeline);
+
+    for await (const workspace of cursor) {
+      yield workspace;
+    }
+  }
+
   /* eslint-disable-next-line */
-    const queue: any[] = [
+  private tariffPlanLookupPipeline(): any[] {
+    return [
       {
         $lookup: {
           from: 'plans',
@@ -66,32 +99,17 @@ export class DbHelper {
         },
       },
       {
-        projection: {
+        $project: {
           _id: 1,
+          name: 1,
           isBlocked: 1,
+          blockedDate: 1,
           lastChargeDate: 1,
+          billingPeriodEventsCount: 1,
           tariffPlan: 1,
-        }
-      }
-    ];
-
-    if (id !== undefined) {
-      queue.unshift({
-        $match: {
-          _id: new ObjectId(id),
         },
-      });
-    }
-
-    const workspaces = this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(queue);
-
-    if (id !== undefined) {
-      return await workspaces.next();
-    }
-
-    for await (const workspace of workspaces) {
-      yield workspace;
-    }
+      },
+    ];
   }
 
   /**

--- a/workers/limiter/src/dbHelper.ts
+++ b/workers/limiter/src/dbHelper.ts
@@ -163,7 +163,7 @@ export class DbHelper {
       ...this.tariffPlanLookupPipeline(),
     ];
 
-    const workspace = this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(pipeline).next();
+    const workspace = await this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(pipeline).next();
 
     if (workspace === null) {
       throw new NonCriticalError(`Workspace ${id} not found`, {

--- a/workers/limiter/src/dbHelper.ts
+++ b/workers/limiter/src/dbHelper.ts
@@ -2,7 +2,7 @@ import { Collection, Db, ObjectId } from 'mongodb';
 import { ProjectDBScheme, WorkspaceDBScheme } from '@hawk.so/types';
 import { WorkspaceWithTariffPlan } from '../types';
 import HawkCatcher from '@hawk.so/nodejs';
-import { CriticalError } from '../../../lib/workerErrors';
+import { CriticalError, NonCriticalError } from '../../../lib/workerErrors';
 
 /**
  * Class that implements methods used for interaction between limiter and db
@@ -44,72 +44,15 @@ export class DbHelper {
    * @param id - id of the workspace to fetch
    */
   public getWorkspacesWithTariffPlans(id: string): Promise<WorkspaceWithTariffPlan>;
+  /**
+   * @param id - id of the workspace to fetch
+   */
   public getWorkspacesWithTariffPlans(id?: string): AsyncGenerator<WorkspaceWithTariffPlan> | Promise<WorkspaceWithTariffPlan> {
     if (id !== undefined) {
       return this.getOneWorkspaceWithTariffPlan(id);
     }
 
     return this.yieldWorkspacesWithTariffPlans();
-  }
-
-  /**
-   * Returns a single workspace with its tariff plan by id
-   *
-   * @param id - workspace id
-   */
-  private async getOneWorkspaceWithTariffPlan(id: string): Promise<WorkspaceWithTariffPlan> {
-    const pipeline = [
-      {
-        $match: {
-          _id: new ObjectId(id),
-        },
-      },
-      ...this.tariffPlanLookupPipeline(),
-    ];
-
-    return this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(pipeline).next();
-  }
-
-  /**
-   * Yields all workspaces with their tariff plans one by one
-   */
-  private async *yieldWorkspacesWithTariffPlans(): AsyncGenerator<WorkspaceWithTariffPlan> {
-    const pipeline = this.tariffPlanLookupPipeline();
-    const cursor = this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(pipeline);
-
-    for await (const workspace of cursor) {
-      yield workspace;
-    }
-  }
-
-  /* eslint-disable-next-line */
-  private tariffPlanLookupPipeline(): any[] {
-    return [
-      {
-        $lookup: {
-          from: 'plans',
-          localField: 'tariffPlanId',
-          foreignField: '_id',
-          as: 'tariffPlan',
-        },
-      },
-      {
-        $unwind: {
-          path: '$tariffPlan',
-        },
-      },
-      {
-        $project: {
-          _id: 1,
-          name: 1,
-          isBlocked: 1,
-          blockedDate: 1,
-          lastChargeDate: 1,
-          billingPeriodEventsCount: 1,
-          tariffPlan: 1,
-        },
-      },
-    ];
   }
 
   /**
@@ -203,5 +146,73 @@ export class DbHelper {
       : {};
 
     return this.projectsCollection.find(query).toArray();
+  }
+
+  /**
+   * Returns a single workspace with its tariff plan by id
+   *
+   * @param id - workspace id
+   */
+  private async getOneWorkspaceWithTariffPlan(id: string): Promise<WorkspaceWithTariffPlan> {
+    const pipeline = [
+      {
+        $match: {
+          _id: new ObjectId(id),
+        },
+      },
+      ...this.tariffPlanLookupPipeline(),
+    ];
+
+    const workspace = this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(pipeline).next();
+
+    if (workspace === null) {
+      throw new NonCriticalError(`Workspace ${id} not found`, {
+        workspaceId: id,
+      });
+    }
+
+    return workspace;
+  }
+
+  /**
+   * Yields all workspaces with their tariff plans one by one
+   */
+  private async * yieldWorkspacesWithTariffPlans(): AsyncGenerator<WorkspaceWithTariffPlan> {
+    const pipeline = this.tariffPlanLookupPipeline();
+    const cursor = this.workspacesCollection.aggregate<WorkspaceWithTariffPlan>(pipeline);
+
+    for await (const workspace of cursor) {
+      yield workspace;
+    }
+  }
+
+  /* eslint-disable-next-line */
+  private tariffPlanLookupPipeline(): any[] {
+    return [
+      {
+        $lookup: {
+          from: 'plans',
+          localField: 'tariffPlanId',
+          foreignField: '_id',
+          as: 'tariffPlan',
+        },
+      },
+      {
+        $unwind: {
+          path: '$tariffPlan',
+        },
+      },
+      {
+        $project: {
+          _id: 1,
+          name: 1,
+          isBlocked: 1,
+          blockedDate: 1,
+          lastChargeDate: 1,
+          billingPeriodEventsCount: 1,
+          tariffPlan: 1,
+        },
+      },
+    ];
   }
 }

--- a/workers/limiter/src/dbHelper.ts
+++ b/workers/limiter/src/dbHelper.ts
@@ -65,6 +65,14 @@ export class DbHelper {
           path: '$tariffPlan',
         },
       },
+      {
+        projection: {
+          _id: 1,
+          isBlocked: 1,
+          lastChargeDate: 1,
+          tariffPlan: 1,
+        }
+      }
     ];
 
     if (id !== undefined) {

--- a/workers/limiter/src/index.ts
+++ b/workers/limiter/src/index.ts
@@ -189,11 +189,11 @@ export default class LimiterWorker extends Worker {
   private async handleRegularWorkspacesCheck(): Promise<void> {
     let message = '';
 
-    const workspaces = await this.dbHelper.getWorkspacesWithTariffPlans();
+    const workspaces = this.dbHelper.getWorkspacesWithTariffPlans();
 
     const updatedWorkspaces: WorkspaceWithTariffPlan[] = [];
 
-    await Promise.all(workspaces.map(async (workspace) => {
+    for await (const workspace of workspaces) {
       /**
        * If workspace is already blocked - do nothing
        */
@@ -226,7 +226,7 @@ export default class LimiterWorker extends Worker {
         this.redis.appendBannedProjects(projectIds);
         message += this.formSingleWorkspaceMessage(updatedWorkspace, projectsToUpdate, 'blocked');
       }
-    }));
+    };
 
     this.dbHelper.updateWorkspacesEventsCountAndIsBlocked(updatedWorkspaces);
 

--- a/workers/limiter/src/index.ts
+++ b/workers/limiter/src/index.ts
@@ -223,7 +223,7 @@ export default class LimiterWorker extends Worker {
         updatedWorkspace.isBlocked = true;
         updatedWorkspace.blockedDate = new Date();
 
-        this.redis.appendBannedProjects(projectIds);
+        await this.redis.appendBannedProjects(projectIds);
         message += this.formSingleWorkspaceMessage(updatedWorkspace, projectsToUpdate, 'blocked');
       }
     }

--- a/workers/limiter/src/index.ts
+++ b/workers/limiter/src/index.ts
@@ -198,7 +198,7 @@ export default class LimiterWorker extends Worker {
        * If workspace is already blocked - do nothing
        */
       if (workspace.isBlocked) {
-        return;
+        continue;
       }
 
       const workspaceProjects = await this.dbHelper.getProjects(workspace._id.toString());
@@ -211,7 +211,7 @@ export default class LimiterWorker extends Worker {
        * If there are no projects to update - move on to next workspace
        */
       if (projectsToUpdate.length === 0) {
-        return;
+        continue;
       }
 
       /**
@@ -226,9 +226,9 @@ export default class LimiterWorker extends Worker {
         this.redis.appendBannedProjects(projectIds);
         message += this.formSingleWorkspaceMessage(updatedWorkspace, projectsToUpdate, 'blocked');
       }
-    };
+    }
 
-    this.dbHelper.updateWorkspacesEventsCountAndIsBlocked(updatedWorkspaces);
+    await this.dbHelper.updateWorkspacesEventsCountAndIsBlocked(updatedWorkspaces);
 
     this.sendRegularReport(message);
   }

--- a/workers/limiter/tests/dbHelper.test.ts
+++ b/workers/limiter/tests/dbHelper.test.ts
@@ -159,16 +159,22 @@ describe('DbHelper', () => {
       /**
        * Act
        */
-      const result = await dbHelper.getWorkspacesWithTariffPlans();
+      const cursor = dbHelper.getWorkspacesWithTariffPlans();
+
+      const workspaces = []
+
+      for await (const workspace of cursor) {
+        workspaces.push(workspace)
+      }
 
       /**
        * Assert
        */
-      expect(result).toHaveLength(2);
-      expect(result[0].tariffPlan).toBeDefined();
-      expect(result[1].tariffPlan).toBeDefined();
-      expect(result[0].tariffPlan.eventsLimit).toBe(10);
-      expect(result[1].tariffPlan.eventsLimit).toBe(10000);
+      expect(workspaces).toHaveLength(2);
+      expect(workspaces[0].tariffPlan).toBeDefined();
+      expect(workspaces[1].tariffPlan).toBeDefined();
+      expect(workspaces[0].tariffPlan.eventsLimit).toBe(10);
+      expect(workspaces[1].tariffPlan.eventsLimit).toBe(10000);
     });
 
     test('Should return single workspace with its tariff plan by id', async () => {

--- a/workers/limiter/tests/dbHelper.test.ts
+++ b/workers/limiter/tests/dbHelper.test.ts
@@ -161,10 +161,10 @@ describe('DbHelper', () => {
        */
       const cursor = dbHelper.getWorkspacesWithTariffPlans();
 
-      const workspaces = []
+      const workspaces = [];
 
       for await (const workspace of cursor) {
-        workspaces.push(workspace)
+        workspaces.push(workspace);
       }
 
       /**

--- a/workers/limiter/types/index.ts
+++ b/workers/limiter/types/index.ts
@@ -3,4 +3,9 @@ import { PlanDBScheme, WorkspaceDBScheme } from '@hawk.so/types';
 /**
  * Workspace with its tariff plan
  */
-export type WorkspaceWithTariffPlan = WorkspaceDBScheme & {tariffPlan: PlanDBScheme};
+export type WorkspaceWithTariffPlan = Pick<
+  WorkspaceDBScheme,
+  '_id' | 'name' | 'isBlocked' | 'blockedDate' | 'lastChargeDate' | 'billingPeriodEventsCount'
+> & {
+  tariffPlan: PlanDBScheme;
+};


### PR DESCRIPTION
## Problem:

hawk.workspaces query has issues with retrieving of all documents at the same time, also it does not have projection and returns whole workspace, that leads to top total execution time and enormous response len
<img width="1200" height="71" alt="image" src="https://github.com/user-attachments/assets/738ffde6-2726-4baa-b8ca-643d76be728b" />

## Solution:

- use projection
- use cursor based retrieving, yield each workspace and store only 1 workspace at a time