### PR TITLE
fix(limiter): handle workspace without tariffPlanId

### DIFF
--- a/workers/limiter/src/dbHelper.ts
+++ b/workers/limiter/src/dbHelper.ts
@@ -259,7 +259,7 @@ export class DbHelper {
     const plan = await this.resolvePlan(workspace.tariffPlanId);
 
     if (!plan) {
-      throw new NonCriticalError(`Tariff plan ${workspace.tariffPlanId.toString()} not found for workspace ${id}`, {
+      throw new NonCriticalError(`Tariff plan ${workspace.tariffPlanId?.toString()} not found for workspace ${id}`, {
         workspaceId: id,
       });
     }

--- a/workers/limiter/src/dbHelper.ts
+++ b/workers/limiter/src/dbHelper.ts
@@ -203,6 +203,13 @@ export class DbHelper {
    * @param planId - id of the plan to find
    */
   private async resolvePlan(planId: WorkspaceDBScheme['tariffPlanId']): Promise<PlanDBScheme | null> {
+    /**
+     * Workspace may have no tariff plan assigned
+     */
+    if (!planId) {
+      return null;
+    }
+
     let plan = this.findPlanById(planId);
 
     if (plan) {

--- a/workers/limiter/tests/dbHelper.test.ts
+++ b/workers/limiter/tests/dbHelper.test.ts
@@ -363,6 +363,60 @@ describe('DbHelper', () => {
       ).rejects.toThrow(NonCriticalError);
     });
 
+    test('Should skip and report a workspace that has no tariffPlanId', async () => {
+      /**
+       * Arrange — a workspace document with a missing tariffPlanId
+       */
+      const workspace = createWorkspaceMock({
+        plan: mockedPlans.eventsLimit10,
+        billingPeriodEventsCount: 0,
+        lastChargeDate: new Date(),
+      });
+
+      delete (workspace as Partial<WorkspaceDBScheme>).tariffPlanId;
+
+      await workspaceCollection.insertOne(workspace);
+
+      const hawkCatcherSpy = jest.spyOn(HawkCatcher, 'send').mockImplementation(() => undefined);
+
+      /**
+       * Act
+       */
+      const workspaces = [];
+
+      for await (const resolved of dbHelper.getWorkspacesWithTariffPlans()) {
+        workspaces.push(resolved);
+      }
+
+      /**
+       * Assert — no crash, the workspace is skipped and reported
+       */
+      expect(workspaces).toHaveLength(0);
+      expect(hawkCatcherSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should throw NonCriticalError when a single workspace has no tariffPlanId', async () => {
+      /**
+       * Arrange
+       */
+      const workspace = createWorkspaceMock({
+        plan: mockedPlans.eventsLimit10,
+        billingPeriodEventsCount: 0,
+        lastChargeDate: new Date(),
+      });
+
+      delete (workspace as Partial<WorkspaceDBScheme>).tariffPlanId;
+
+      await workspaceCollection.insertOne(workspace);
+
+      /**
+       * Act & Assert
+       */
+      await expect(
+        dbHelper.getWorkspacesWithTariffPlans(workspace._id.toString())
+      ).rejects.toThrow(NonCriticalError);
+    });
+
     test('fetchPlans should throw CriticalError when the plans collection is empty', async () => {
       /**
        * Arrange — a helper pointed at an empty plans collection


### PR DESCRIPTION
A workspace with no tariffPlanId made resolvePlan crash on planId.toString().