### PR TITLE
feat(grouper): propagate occurrence count to totalCount and repetitions

### DIFF
--- a/lib/event-worker.ts
+++ b/lib/event-worker.ts
@@ -27,6 +27,7 @@ export abstract class EventWorker extends Worker {
       catcherType: this.type as CatcherMessageType,
       payload: task.payload as CatcherMessagePayload<ErrorsCatcherType>,
       timestamp: task.timestamp,
+      count: task.count,
     } as GroupWorkerTask<ErrorsCatcherType>);
   }
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@babel/parser": "^7.26.9",
         "@babel/traverse": "7.26.9",
         "@hawk.so/nodejs": "^3.1.1",
-        "@hawk.so/types": "^0.5.9",
+        "@hawk.so/types": "^0.6.4",
         "@types/amqplib": "^0.8.2",
         "@types/jest": "^29.5.14",
         "@types/mongodb": "^3.5.15",

--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -273,7 +273,7 @@ export default class GrouperWorker extends Worker {
         await session.measureStep('saveNewEvent', () => {
           return this.saveEvent(task.projectId, {
             groupHash: uniqueEventHash,
-            totalCount: 1,
+            totalCount: task.count ?? 1,
             catcherType: task.catcherType,
             payload: task.payload,
             timestamp: task.timestamp,
@@ -321,7 +321,7 @@ export default class GrouperWorker extends Worker {
       await session.measureStep('incrementCounter', () => {
         return this.incrementEventCounterAndAffectedUsers(task.projectId, {
           groupHash: uniqueEventHash,
-        }, incrementAffectedUsers);
+        }, incrementAffectedUsers, task.count ?? 1);
       });
 
       /**
@@ -363,6 +363,15 @@ export default class GrouperWorker extends Worker {
         timestamp: task.timestamp,
       } as RepetitionDBScheme;
 
+      /**
+       * Store count only when it carries information (>1)
+       * Absent or 1 both mean "single occurrence",
+       * so omitting it keeps repetition documents lean.
+       */
+      if (task.count !== undefined && task.count > 1) {
+        newRepetition.count = task.count;
+      }
+
       repetitionId = await session.measureStep('saveRepetition', () => {
         return this.saveRepetition(task.projectId, newRepetition);
       });
@@ -388,7 +397,8 @@ export default class GrouperWorker extends Worker {
         uniqueEventHash,
         task.timestamp,
         repetitionId,
-        incrementDailyAffectedUsers
+        incrementDailyAffectedUsers,
+        task.count ?? 1
       );
     });
 
@@ -841,8 +851,9 @@ export default class GrouperWorker extends Worker {
    * @param projectId - project id to increment
    * @param query - query to get event
    * @param incrementAffected - if true, usersAffected counter will be incremented
+   * @param incrementBy - how many occurrences this repetition represents
    */
-  private async incrementEventCounterAndAffectedUsers(projectId, query, incrementAffected: boolean): Promise<number> {
+  private async incrementEventCounterAndAffectedUsers(projectId, query, incrementAffected: boolean, incrementBy = 1): Promise<number> {
     if (!projectId || !mongodb.ObjectID.isValid(projectId)) {
       throw new ValidationError('Controller.saveEvent: Project ID is invalid or missed');
     }
@@ -852,13 +863,13 @@ export default class GrouperWorker extends Worker {
         const updateQuery = incrementAffected
           ? {
             $inc: {
-              totalCount: 1,
+              totalCount: incrementBy,
               usersAffected: 1,
             },
           }
           : {
             $inc: {
-              totalCount: 1,
+              totalCount: incrementBy,
             },
           };
 
@@ -879,6 +890,7 @@ export default class GrouperWorker extends Worker {
    * @param {string} eventTimestamp - timestamp of the last event
    * @param {string|null} repetitionId - event's last repetition id
    * @param {boolean} shouldIncrementAffectedUsers - whether to increment affected users
+   * @param {number} incrementBy - how many occurrences this task represents
    * @returns {Promise<void>}
    */
   private async saveDailyEvents(
@@ -886,7 +898,8 @@ export default class GrouperWorker extends Worker {
     eventHash: string,
     eventTimestamp: number,
     repetitionId: string | null,
-    shouldIncrementAffectedUsers: boolean
+    shouldIncrementAffectedUsers: boolean,
+    incrementBy = 1
   ): Promise<void> {
     if (!projectId || !mongodb.ObjectID.isValid(projectId)) {
       throw new ValidationError('GrouperWorker.saveDailyEvents: Project ID is invalid or missed');
@@ -911,7 +924,7 @@ export default class GrouperWorker extends Worker {
                 lastRepetitionId: repetitionId,
               },
               $inc: {
-                count: 1,
+                count: incrementBy,
                 affectedUsers: shouldIncrementAffectedUsers ? 1 : 0,
               },
             },

--- a/workers/grouper/tests/index.test.ts
+++ b/workers/grouper/tests/index.test.ts
@@ -79,12 +79,14 @@ const projectMock = {
  *
  * @param event - allows to override some event properties in generated task
  * @param timestamp - timestamp of the event, defaults to current time
+ * @param count - number of occurrences this task represents
  */
-function generateTask(event: Partial<EventData<EventAddons>> = undefined, timestamp: number = new Date().getTime()): GroupWorkerTask<ErrorsCatcherType> {
+function generateTask(event: Partial<EventData<EventAddons>> = undefined, timestamp: number = new Date().getTime(), count: number = undefined): GroupWorkerTask<ErrorsCatcherType> {
   return {
     projectId: projectIdMock,
     catcherType: 'errors/javascript',
     timestamp,
+    count,
     payload: Object.assign({
       title: 'Hawk client catcher test',
       backtrace: [],
@@ -180,6 +182,19 @@ describe('GrouperWorker', () => {
       await worker.handle(generateTask());
 
       expect((await eventsCollection.findOne({})).totalCount).toBe(4);
+    });
+
+    test('Should set total events count to repetition count on first occurrence when count is provided', async () => {
+      await worker.handle(generateTask(undefined, undefined, 5));
+
+      expect((await eventsCollection.findOne({})).totalCount).toBe(5);
+    });
+
+    test('Should increment total events count by repetition count on processing when count is provided', async () => {
+      await worker.handle(generateTask(undefined, undefined, 3));
+      await worker.handle(generateTask(undefined, undefined, 2));
+
+      expect((await eventsCollection.findOne({})).totalCount).toBe(5);
     });
 
     test('Should not increment total usersAffected count if it is event from first user', async () => {
@@ -351,6 +366,13 @@ describe('GrouperWorker', () => {
       expect((await dailyEventsCollection.findOne({})).count).toBe(4);
     });
 
+    test('Should update events count per day by repetition count', async () => {
+      await worker.handle(generateTask(undefined, undefined, 3));
+      await worker.handle(generateTask(undefined, undefined, 2));
+
+      expect((await dailyEventsCollection.findOne({})).count).toBe(5);
+    });
+
     test('Should update last repetition id', async () => {
       await worker.handle(generateTask());
       await worker.handle(generateTask());
@@ -372,6 +394,33 @@ describe('GrouperWorker', () => {
       expect((await repetitionsCollection.find({
         groupHash: originalEvent.groupHash,
       }).toArray()).length).toBe(2);
+    });
+
+    test('Should save repetition count when count is greater than 1', async () => {
+      await worker.handle(generateTask());
+      await worker.handle(generateTask(undefined, undefined, 7));
+
+      const savedRepetition = await repetitionsCollection.findOne({});
+
+      expect(savedRepetition.count).toBe(7);
+    });
+
+    test('Should omit repetition count when count is absent', async () => {
+      await worker.handle(generateTask());
+      await worker.handle(generateTask());
+
+      const savedRepetition = await repetitionsCollection.findOne({});
+
+      expect(savedRepetition.count).toBeUndefined();
+    });
+
+    test('Should omit repetition count when count is exactly 1', async () => {
+      await worker.handle(generateTask());
+      await worker.handle(generateTask(undefined, undefined, 1));
+
+      const savedRepetition = await repetitionsCollection.findOne({});
+
+      expect(savedRepetition.count).toBeUndefined();
     });
 
     test('Should stringify delta', async () => {

--- a/workers/javascript/src/index.ts
+++ b/workers/javascript/src/index.ts
@@ -94,6 +94,7 @@ export default class JavascriptEventWorker extends EventWorker {
       catcherType: this.type as CatcherMessageType,
       payload: event.payload as CatcherMessagePayload<CatcherMessageType>,
       timestamp: event.timestamp,
+      count: event.count,
     } as GroupWorkerTask<ErrorsCatcherType>);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,10 +402,10 @@
   dependencies:
     "@types/mongodb" "^3.5.34"
 
-"@hawk.so/types@^0.5.9":
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/@hawk.so/types/-/types-0.5.9.tgz#817e8b26283d0367371125f055f2e37a274797bc"
-  integrity sha512-86aE0Bdzvy8C+Dqd1iZpnDho44zLGX/t92SGuAv2Q52gjSJ7SHQdpGDWtM91FXncfT5uzAizl9jYMuE6Qrtm0Q==
+"@hawk.so/types@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@hawk.so/types/-/types-0.6.4.tgz#cf9c54b07ffd4ef34a53b5b9382d462750bc3c1d"
+  integrity sha512-lPbEa1Lr6tFxR1j4B1/r7IWXtnclt4obegeqaq5anx+8ShPPN9Cw7r4u+G0KzvfLfe8uAEGbW7Cd80s9jtlIHA==
   dependencies:
     bson "^7.0.0"
 


### PR DESCRIPTION
- event-worker / javascript worker: forward CatcherMessage.count to the
  grouper task instead of dropping it
- grouper: use count instead of a hardcoded 1 when
  - setting totalCount on first occurrence
  - incrementing totalCount on repetitions
  - incrementing the daily events aggregate
- grouper: record count on the repetition document itself, omitted when
  absent or 1 (single occurrence), set when a message represents more
  than one real occurrence

Draft: depends on @hawk.so/types publishing CatcherMessage.count /
RepetitionDBScheme.count (codex-team/hawk.types#76).