### PR TITLE
chore(data-filter): cap backtrace frames

### DIFF
--- a/workers/grouper/src/data-filter.ts
+++ b/workers/grouper/src/data-filter.ts
@@ -14,6 +14,22 @@ const MAX_TRAVERSAL_DEPTH = 20;
 const MAX_TITLE_LENGTH = 400;
 
 /**
+ * Maximum number of backtrace frames to keep.
+ * Deep Rails stacks (200+ frames with sourceCode) inflate stored events and list API responses.
+ */
+const MAX_BACKTRACE_FRAMES = 20;
+
+/**
+ * Maximum sourceCode lines kept per backtrace frame
+ */
+const MAX_SOURCE_CODE_LINES = 21;
+
+/**
+ * Maximum length of a single source code line
+ */
+const MAX_CODE_LINE_LENGTH = 140;
+
+/**
  * Recursively iterate through object and call function on each key
  *
  * @param obj - Object to iterate
@@ -143,6 +159,7 @@ export default class DataFilter {
    */
   public processEvent(event: EventData<EventAddons>): void {
     this.trimEventTitle(event);
+    this.trimBacktrace(event);
     this.sanitizeEvent(event);
 
     unsafeFields.forEach(field => {
@@ -162,6 +179,54 @@ export default class DataFilter {
     if (typeof event.title === 'string') {
       event.title = rightTrim(event.title, MAX_TITLE_LENGTH);
     }
+  }
+
+  /**
+   * Cap backtrace frames and sourceCode size.
+   * It mutates the original object.
+   *
+   * @param event - event to process
+   */
+  public trimBacktrace(event: EventData<EventAddons>): void {
+    if (!Array.isArray(event.backtrace)) {
+      return;
+    }
+
+    if (event.backtrace.length === 0) {
+      /**
+       * Normalize empty backtrace — empty arrays lead to visual bugs
+       */
+      delete event.backtrace;
+
+      return;
+    }
+
+    if (event.backtrace.length > MAX_BACKTRACE_FRAMES) {
+      event.backtrace = event.backtrace.slice(0, MAX_BACKTRACE_FRAMES);
+    }
+
+    event.backtrace.forEach((frame) => {
+      if (!frame || !Array.isArray(frame.sourceCode)) {
+        return;
+      }
+
+      const sourceCode = frame.sourceCode.length > MAX_SOURCE_CODE_LINES
+        ? frame.sourceCode.slice(0, MAX_SOURCE_CODE_LINES)
+        : frame.sourceCode;
+
+      frame.sourceCode = sourceCode.map((line) => {
+        if (!line || typeof line !== 'object') {
+          return line;
+        }
+
+        return {
+          ...line,
+          content: typeof line.content === 'string'
+            ? rightTrim(line.content, MAX_CODE_LINE_LENGTH)
+            : line.content,
+        };
+      });
+    });
   }
 
   /**
@@ -275,3 +340,10 @@ export default class DataFilter {
     return value;
   }
 }
+
+export {
+  MAX_BACKTRACE_FRAMES,
+  MAX_SOURCE_CODE_LINES,
+  MAX_CODE_LINE_LENGTH,
+  MAX_TITLE_LENGTH,
+};

--- a/workers/grouper/src/index.ts
+++ b/workers/grouper/src/index.ts
@@ -7,11 +7,7 @@ import * as WorkerNames from '../../../lib/workerNames';
 import * as pkg from '../package.json';
 import type { GroupWorkerTask, RepetitionDelta } from '../types/group-worker-task';
 import type {
-  EventAddons,
-  EventData,
   GroupedEventDBScheme,
-  BacktraceFrame,
-  SourceCodeLine,
   ProjectEventGroupingPatternsDBScheme,
   ErrorsCatcherType
 } from '@hawk.so/types';
@@ -24,8 +20,6 @@ import DataFilter from './data-filter';
 import RedisHelper from './redisHelper';
 import { computeDelta } from './utils/repetitionDiff';
 import { bucketTimestampMs } from './utils/bucketTimestamp';
-import { rightTrim } from '../../../lib/utils/string';
-import { hasValue } from '../../../lib/utils/hasValue';
 import GrouperMetrics from './metrics/grouperMetrics';
 import GrouperMemoryMonitor from './metrics/memoryMonitor';
 import SlowHandleDiagnostics, { SlowHandleSession } from './metrics/slowHandleDiagnostics';
@@ -57,11 +51,6 @@ const DB_DUPLICATE_KEY_ERROR = '11000';
  * Retention period for daily Redis TimeSeries metrics in days
  */
 const DAILY_METRICS_RETENTION_DAYS = 90;
-
-/**
- * Maximum length for backtrace code line
- */
-const MAX_CODE_LINE_LENGTH = 140;
 
 /**
  * Worker for handling Javascript events
@@ -216,13 +205,6 @@ export default class GrouperWorker extends Worker {
     let existedEvent: GroupedEventDBScheme;
     let repetitionId = null;
     let incrementDailyAffectedUsers = false;
-
-    await session.measureStep('preprocess', () => {
-      /**
-       * Trim source code lines to prevent memory leaks
-       */
-      this.trimSourceCodeLines(task.payload);
-    });
 
     /**
      * Find similar events by grouping pattern
@@ -491,37 +473,6 @@ export default class GrouperWorker extends Worker {
       } catch (error) {
         this.logger.error(`Failed to add ${label} TS for ${metricType}`, error);
       }
-    }
-  }
-
-  /**
-   * Trims source code lines in event's backtrace to prevent memory leaks
-   *
-   * @param event - event to process
-   */
-  private trimSourceCodeLines(event: EventData<EventAddons>): void {
-    if (!event.backtrace) {
-      return;
-    }
-
-    event.backtrace.forEach((frame: BacktraceFrame) => {
-      if (!frame.sourceCode) {
-        return;
-      }
-
-      frame.sourceCode = frame.sourceCode.map((line: SourceCodeLine) => {
-        return {
-          line: line.line,
-          content: hasValue(line.content) ? rightTrim(line.content, MAX_CODE_LINE_LENGTH) : line.content,
-        };
-      });
-    });
-
-    /**
-     * Normalize backtrace, if backtrace equals to [] it leads to visual bugs
-     */
-    if (event.backtrace.length === 0) {
-      event.backtrace = null;
     }
   }
 

--- a/workers/grouper/tests/data-filter.test.ts
+++ b/workers/grouper/tests/data-filter.test.ts
@@ -517,4 +517,38 @@ describe('GrouperWorker', () => {
       expect(event.context['self']).toBe('<circular>');
     });
   });
+
+  describe('Backtrace trimming', () => {
+    test('should cap backtrace frames and sourceCode lines', () => {
+      const longLine = 'x'.repeat(300);
+      const backtrace = Array.from({ length: 80 }, (_, index) => {
+        return {
+          file: `frame-${index}.rb`,
+          line: index + 1,
+          sourceCode: Array.from({ length: 25 }, (__, lineIndex) => {
+            return {
+              line: lineIndex + 1,
+              content: longLine,
+            };
+          }),
+        };
+      });
+      const event = generateEvent({ backtrace });
+
+      dataFilter.processEvent(event);
+
+      expect(event.backtrace).toHaveLength(20);
+      expect(event.backtrace?.[0].sourceCode).toHaveLength(21);
+      expect(event.backtrace?.[0].sourceCode?.[0].content?.endsWith('…')).toBe(true);
+      expect(event.backtrace?.[0].sourceCode?.[0].content?.length).toBeLessThanOrEqual(141);
+    });
+
+    test('should normalize empty backtrace to undefined', () => {
+      const event = generateEvent({ backtrace: [] });
+
+      dataFilter.processEvent(event);
+
+      expect(event.backtrace).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Some projects sends bloated backtraces with 80-250 frames that took too much memory.

This PR improves Grouper's DataFilter logic to cap such backtrace frames (max 20 frames).